### PR TITLE
feat: PrismDeviceCredential entity + Umbraco migration (#12)

### DIFF
--- a/src/UmbracoPrism.Core/Models/PrismDeviceCredential.cs
+++ b/src/UmbracoPrism.Core/Models/PrismDeviceCredential.cs
@@ -1,0 +1,72 @@
+namespace UmbracoPrism.Core.Models;
+
+/// <summary>
+/// Represents a registered biometric device credential in the Prism device registry.
+/// </summary>
+public class PrismDeviceCredential
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the device credential record.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client-generated device UUID, stored as a string.
+    /// </summary>
+    public string DeviceId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the tenant identifier this credential is scoped to.
+    /// </summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Entra Object ID of the user who registered this credential.
+    /// </summary>
+    public string UserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the user-provided friendly name for the device. May be null.
+    /// </summary>
+    public string? DeviceName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SHA-256 hash of the BiometricToken JWT used for exchange validation.
+    /// </summary>
+    public string TokenHash { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of consecutive failed exchange attempts for rate-limiting.
+    /// </summary>
+    public int FailedAttempts { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC datetime until which exchange attempts are locked out. Null means not locked.
+    /// </summary>
+    public DateTime? LockedUntil { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC datetime when this credential was registered.
+    /// </summary>
+    public DateTime RegisteredAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC datetime when this credential was last successfully used. Null if never used.
+    /// </summary>
+    public DateTime? LastUsedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC datetime when this credential expires. Default is 30 days from registration.
+    /// </summary>
+    public DateTime ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC datetime when this credential was revoked. Null means active.
+    /// </summary>
+    public DateTime? RevokedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the device platform. Expected values: 'ios' or 'android'. May be null.
+    /// </summary>
+    public string? Platform { get; set; }
+}

--- a/src/UmbracoPrism.Core/Persistence/CreatePrismDeviceCredentialsTable.cs
+++ b/src/UmbracoPrism.Core/Persistence/CreatePrismDeviceCredentialsTable.cs
@@ -1,0 +1,34 @@
+using Umbraco.Cms.Infrastructure.Migrations;
+
+namespace UmbracoPrism.Core.Persistence;
+
+/// <summary>
+/// Migration that creates the prismDeviceCredentials table for the biometric device registry.
+/// </summary>
+public class CreatePrismDeviceCredentialsTable(IMigrationContext context) : AsyncMigrationBase(context)
+{
+    protected override Task MigrateAsync()
+    {
+        if (!TableExists("prismDeviceCredentials"))
+        {
+            Create.Table<PrismDeviceCredentialSchema>().Do();
+
+            // Unique composite index: one DeviceId per tenant
+            Database.Execute(@"
+                CREATE UNIQUE INDEX IX_prismDeviceCredentials_TenantId_DeviceId
+                ON prismDeviceCredentials (TenantId, DeviceId);");
+
+            // Lookup index: all credentials for a user within a tenant
+            Database.Execute(@"
+                CREATE INDEX IX_prismDeviceCredentials_TenantId_UserId
+                ON prismDeviceCredentials (TenantId, UserId);");
+
+            // Exchange validation: token hash lookup
+            Database.Execute(@"
+                CREATE INDEX IX_prismDeviceCredentials_TokenHash
+                ON prismDeviceCredentials (TokenHash);");
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/UmbracoPrism.Core/Persistence/PrismDeviceCredentialSchema.cs
+++ b/src/UmbracoPrism.Core/Persistence/PrismDeviceCredentialSchema.cs
@@ -1,0 +1,105 @@
+using NPoco;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+
+namespace UmbracoPrism.Core.Persistence;
+
+/// <summary>
+/// Database schema for the prismDeviceCredentials table.
+/// </summary>
+[TableName("prismDeviceCredentials")]
+[PrimaryKey("id", AutoIncrement = true)]
+[ExplicitColumns]
+public class PrismDeviceCredentialSchema
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the device credential record.
+    /// </summary>
+    [Column("id")]
+    [PrimaryKeyColumn(AutoIncrement = true)]
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client-generated device UUID, stored as a string.
+    /// </summary>
+    [Column("DeviceId")]
+    [Length(64)]
+    public string DeviceId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the tenant identifier this credential is scoped to.
+    /// </summary>
+    [Column("TenantId")]
+    [Length(450)]
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Entra Object ID of the user who registered this credential.
+    /// </summary>
+    [Column("UserId")]
+    [Length(450)]
+    public string UserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the user-provided friendly name for the device. May be null.
+    /// </summary>
+    [Column("DeviceName")]
+    [Length(255)]
+    [NullSetting(NullSetting = NullSettings.Null)]
+    public string? DeviceName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SHA-256 hash of the BiometricToken JWT used for exchange validation.
+    /// </summary>
+    [Column("TokenHash")]
+    [Length(512)]
+    public string TokenHash { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of consecutive failed exchange attempts for rate-limiting.
+    /// </summary>
+    [Column("FailedAttempts")]
+    [Constraint(Default = "0")]
+    public int FailedAttempts { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC datetime until which exchange attempts are locked out. Null means not locked.
+    /// </summary>
+    [Column("LockedUntil")]
+    [NullSetting(NullSetting = NullSettings.Null)]
+    public DateTime? LockedUntil { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC datetime when this credential was registered.
+    /// </summary>
+    [Column("RegisteredAt")]
+    [Constraint(Default = "getutcdate()")]
+    public DateTime RegisteredAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC datetime when this credential was last successfully used.
+    /// </summary>
+    [Column("LastUsedAt")]
+    [NullSetting(NullSetting = NullSettings.Null)]
+    public DateTime? LastUsedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC datetime when this credential expires.
+    /// </summary>
+    [Column("ExpiresAt")]
+    public DateTime ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC datetime when this credential was revoked. Null means active.
+    /// </summary>
+    [Column("RevokedAt")]
+    [NullSetting(NullSetting = NullSettings.Null)]
+    public DateTime? RevokedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the device platform ('ios' or 'android'). May be null.
+    /// </summary>
+    [Column("Platform")]
+    [Length(50)]
+    [NullSetting(NullSetting = NullSettings.Null)]
+    public string? Platform { get; set; }
+}

--- a/src/UmbracoPrism.Core/Persistence/PrismMigrationPlan.cs
+++ b/src/UmbracoPrism.Core/Persistence/PrismMigrationPlan.cs
@@ -23,6 +23,7 @@ public class PrismMigrationPlan : PackageMigrationPlan
         .To<AddIdentityColumns>("add-identity-cols")
         .To<AddBrandingOverridesColumn>("add-branding-overrides")
         .To<AddMobileBrandingOverridesColumn>("add-mobile-branding-overrides")
-        .To<AddMobileAppConfigColumn>("add-mobile-app-config");
+        .To<AddMobileAppConfigColumn>("add-mobile-app-config")
+        .To<CreatePrismDeviceCredentialsTable>("add-device-credentials");
     }
 }


### PR DESCRIPTION
## Summary
Adds the `PrismDeviceCredential` entity and Umbraco `PrismMigrationPlan` migration for the biometric device registry.

## Changes
- New model: `PrismDeviceCredential` (plain POCO, `Models/` — matches `PrismTenant` style)
- New schema: `PrismDeviceCredentialSchema` (NPoco annotations, `Persistence/` — matches `PrismTenantSchema` style)
- New migration: `CreatePrismDeviceCredentialsTable` — creates table + 3 indexes via `Database.Execute` (composite indexes not supported by `[Index]` attribute)
- `PrismMigrationPlan` updated: chained as `add-device-credentials` step after `add-mobile-app-config`

## Schema fields
`Id`, `DeviceId`, `TenantId`, `UserId`, `DeviceName`, `TokenHash`, `FailedAttempts` (default 0), `LockedUntil`, `RegisteredAt` (default getutcdate()), `LastUsedAt`, `ExpiresAt`, `RevokedAt`, `Platform`

## Indexes
- `UNIQUE (TenantId, DeviceId)` — one device per tenant
- `(TenantId, UserId)` — user credential lookup
- `(TokenHash)` — exchange validation

## Design reference
See `Design/biometric-auth.md` — DB Schema and Device Registry sections.

Working as Blathers (Backend Dev)

Closes #12