### PR TITLE
fix(auth): inject X-Forwarded headers on backchannel refresh to fix invalid_grant

### DIFF
--- a/.squad/agents/blathers/history.md
+++ b/.squad/agents/blathers/history.md
@@ -1,5 +1,24 @@
 # Blathers — History
 
+## Session: Refresh Token `invalid_grant` Fix — fix/codespaces-invalid-grant-refresh (2026-05-15)
+
+**Status:** ✅ Complete — branch `fix/codespaces-invalid-grant-refresh`
+
+**Scope:** Diagnosed and fixed a persistent `invalid_grant` 401 on the Codespaces "Call Mock Business App API" demo. Root cause: Keycloak 26 with `--proxy-headers xforwarded` uses `X-Forwarded-Proto` to compute its canonical issuer URL scheme. Without that header on the backchannel refresh POST, Keycloak computed its issuer as `http://...` but the stored refresh token's `iss` JWT claim was `https://...` (issued through YARP which forwards proper headers). The scheme mismatch triggered `invalid_grant`. The initial code exchange was unaffected because authorization codes are opaque DB lookups with no `iss` claim to compare.
+
+**Changes:**
+- `IPrismTokenRefreshService` — added optional `requestHeaders` param to `RefreshAsync`
+- `PrismTokenRefreshService` — changed to `HttpRequestMessage`/`SendAsync` to support per-request headers
+- `PrismContext.RefreshTokenAsync` — derives `X-Forwarded-Proto`/`X-Forwarded-Host` from `OidcAuthority` when backchannel rewrite active; passes to `RefreshAsync`
+- `BackchannelRewriteTests.cs` — Group E: 3 new regression tests for forwarding header behaviour
+- Updated existing mocks in `PrismContextTests.cs`, `LocalhostGenericOidcRegressionTests.cs`, `BiometricControllerTests.cs` to include 4th param
+
+**Security bedrock:** `ValidIssuer` remains `tenant.OidcAuthority` (public HTTPS URL). Forwarding headers only affect Keycloak's grant computation; Prism's own validation is unchanged.
+
+**Test results:** 645 passed, 0 failed, 0 skipped.
+
+---
+
 ## Session: JWKS Backchannel Rewrite — fix/codespaces-401-downstream-auth (2026-05-02)
 
 **Status:** ✅ Complete — commit `4a47acc` pushed to `fix/codespaces-401-downstream-auth`

--- a/.squad/agents/copper/history.md
+++ b/.squad/agents/copper/history.md
@@ -9,6 +9,33 @@ Previous history archived to reduce file size. Recent entries below.
 
 ---
 
+## 2026-05-02 — PR #45 Security Review: Codespaces URL Derivation Fix
+
+**Verdict:** APPROVED WITH NOTES
+
+**Context:** PR #45 fixes Codespaces URL derivation to handle both the legacy `{CODESPACE_NAME}-{port}.app.github.dev` and new regional `{token}-{port}.{region}.app.github.dev` URL schemes, using `gh codespace ports` as the authoritative source. Changes span AppHost URL discovery, DemoTenantSeeder, TenantService fallback lookup, and TestSite Request.Host override.
+
+**Bedrock Preserved:**
+- RequireHttpsMetadata untouched; BackchannelRewriteTests security gate continues passing.
+- ValidateIssuer/Audience re-enabled in IssuerSigningKeyResolver from DB values, not request headers.
+- Backchannel dual gate unchanged (codespaceName env var gate + IsDevelopment() throw-guard in TestSite).
+- IsRepoOwnedLocalDemoTenant semantics unchanged for non-Codespace traffic (hostname check uses tenant.Hostname from DB).
+- JWT issuer/audience strings come from tenant DB row, not request. New regression test confirms this for regional URL scheme.
+
+**Soft Notes Raised:**
+1. `TenantService` LIKE fallback (`%.app.github.dev`) has no ORDER BY — non-deterministic row selection if multiple .app.github.dev rows exist (orphan rows from token rotation). Not exploitable; could cause dev confusion.
+2. LIKE fallback not gated by IsDevelopment() in TenantService. Defense-in-depth concern only (seeder is already dev-gated so no production .app.github.dev rows can exist).
+
+**Key Learning:**
+- Request.Host override from a static env var (TESTSITE_PUBLIC_URL) is SAFER than reading the inbound Host header — it overrides whatever the client sends, making host-header injection impossible on that path.
+- The `gh codespace ports` startup-only pattern (ProcessStartInfo without shell, JSON.TryCreate downstream) is injection-safe and provides the correct authoritativ URL for both Codespace URL schemes.
+- When reviewing hostname-based tenant fallbacks, trace whether the returned tenant.Hostname (from DB) or the inbound request hostname is used for OIDC configuration downstream. In this PR, DB values are always the source — the fallback is config-routing only.
+
+**Test Results:** 647/647 passed (0 failures).
+**Artifacts:** `.squad/decisions/inbox/copper-pr45-security-review.md`
+
+---
+
 - User Impact: ✅ Positive (fresh clones work without manual Keycloak config)
 
 **Alignment:**

--- a/.squad/agents/tangy/history.md
+++ b/.squad/agents/tangy/history.md
@@ -10,6 +10,48 @@ QA validation, test coverage analysis, and edge-case identification.
 
 ---
 
+## 2026-05-02 — PR #45 Test Review: Codespaces URL Derivation Fix
+
+**Status:** ✅ APPROVED WITH NOTES  
+**Test result:** 647 passed, 0 failed, 0 skipped
+
+### Criteria Outcomes
+
+| # | Criterion | Result |
+|---|-----------|--------|
+| 1 | New `{token}-{port}.{region}.app.github.dev` URL form tested | ✅ Group D — 2 tests |
+| 2 | Regression test for JWKS fetch / 401 symptom | ✅ `JwksFetch_RewritesUrl_ForRegionalCodespacesUrlScheme` |
+| 3 | Request.Host override middleware tested | ⚠️ NO unit test |
+| 4 | `IsRepoOwnedLocalDemoTenant` False-case for non-demo hosts | ✅ `IsRepoOwnedLocalDemoTenant_ReturnsFalse_ForNonCodespacesDomain` |
+| 4b | `TenantService.GetByDomainAsync` lenient LIKE fallback tested | ⚠️ NO test |
+| 5 | No deleted/skipped/ignored tests | ✅ Clean |
+
+### Follow-up Gaps (non-blocking)
+
+1. **`TenantService.GetByDomainAsync` lenient LIKE fallback** — The `LIKE '%.app.github.dev'`
+   fallback added to `TenantService.cs` (the key runtime fix enabling new-scheme tenant lookup)
+   has no unit test. Need: one positive case (regional URL falls back to seeded tenant) and one
+   negative case (non-.app.github.dev does NOT trigger fallback). → `TenantServiceCacheStrategyTests.cs`
+
+2. **Request.Host override middleware** — `TestSite/Program.cs` inline middleware (reads
+   `TESTSITE_PUBLIC_URL`, overrides `Request.Host` for HTTPS) is untested. → New test class or
+   extend `PrismTenantMiddlewareTests`.
+
+### Key Learning
+
+When reviewing a "multi-surface" fix (AppHost URL discovery + middleware + seeder + service layer),
+map each code surface to a test and flag any that have no corresponding unit test. The most
+dangerous surfaces are the service-layer fallback (TenantService LIKE) and the middleware Host
+override — both are silent runtime logic with no compile-time errors if they break.
+
+Token refresh (`RefreshTokenAsync`) was not specifically tested with a regional URL form as
+authority, but the risk is low because `BackchannelRewritingDocumentRetriever` operates on URI
+origins — the JWKS test proves the same path. Still worth noting as a low-priority gap.
+
+---
+
+---
+
 ## 📌 2026-04-30: Cross-Agent Note — V2 Decimal Validation Test Coverage
 
 **Context:** Blathers' 2026-04-28 option 1 fix added decimal field validation. Noted as blind spot: "No compile-time guarantee all field types handled in validator."

--- a/src/UmbracoPrism.Core.Tests/BackchannelRewriteTests.cs
+++ b/src/UmbracoPrism.Core.Tests/BackchannelRewriteTests.cs
@@ -380,9 +380,10 @@ public class BackchannelRewriteTests
             .Setup(t => t.RefreshAsync(
                 It.IsAny<string>(),
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, IReadOnlyDictionary<string, string>, CancellationToken>(
-                (endpoint, _, _) => onRefreshCall(endpoint))
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+            .Callback<string, IReadOnlyDictionary<string, string>, CancellationToken, IReadOnlyDictionary<string, string>?>(
+                (endpoint, _, _, _) => onRefreshCall(endpoint))
             .ReturnsAsync(new TokenRefreshResult(true, "new-access-token", "new-refresh-token", 3600));
 
         var prismContext = new PrismContext(accessor, vault.Object, tokenRefreshService.Object)
@@ -491,6 +492,146 @@ public class BackchannelRewriteTests
         identity.AddClaim(new Claim("iss", issuer));
         identity.AddClaim(new Claim("aud", clientId));
         return new ClaimsPrincipal(identity);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Group E — X-Forwarded headers on backchannel refresh (invalid_grant fix)
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// When the backchannel rewrite is active, X-Forwarded-Proto and X-Forwarded-Host
+    /// must be passed to RefreshAsync so Keycloak (running with --proxy-headers xforwarded)
+    /// computes its canonical issuer as the public HTTPS authority.
+    ///
+    /// Without these headers Keycloak sees the backchannel HTTP request and derives its
+    /// issuer as http://... while the stored refresh token's iss claim is https://... —
+    /// the scheme mismatch causes Keycloak to return invalid_grant.
+    /// </summary>
+    [Fact]
+    public async Task RefreshTokenAsync_SendsForwardingHeaders_WhenBackchannelRewriteActive()
+    {
+        using var envDev = new TempEnvVar("ASPNETCORE_ENVIRONMENT", "Development");
+        using var envBc = new TempEnvVar("KEYCLOAK_BACKCHANNEL_URL", BackchannelUrl);
+
+        IReadOnlyDictionary<string, string>? capturedHeaders = null;
+        var (prismContext, _) = BuildPrismContextWithHeaderCapture(
+            OidcAuthority, ClientId,
+            headers => capturedHeaders = headers);
+
+        await prismContext.GetAuthorizationHeaderAsync();
+
+        capturedHeaders.Should().NotBeNull("forwarding headers must be passed on the backchannel path");
+        capturedHeaders!.Should().ContainKey("X-Forwarded-Proto");
+        capturedHeaders["X-Forwarded-Proto"].Should().Be("https",
+            "the public OidcAuthority scheme is https so Keycloak must compute an https issuer");
+        capturedHeaders.Should().ContainKey("X-Forwarded-Host");
+        capturedHeaders["X-Forwarded-Host"].Should().Be(new Uri(OidcAuthority).Host,
+            "Keycloak must see the public hostname, not localhost");
+    }
+
+    /// <summary>
+    /// On the non-backchannel path (no rewrite), no X-Forwarded headers must be injected.
+    /// Adding forwarding headers to a direct HTTPS call to the public Keycloak endpoint
+    /// would be redundant and could confuse reverse proxies.
+    /// </summary>
+    [Fact]
+    public async Task RefreshTokenAsync_DoesNotSendForwardingHeaders_WhenBackchannelUnset()
+    {
+        using var envBc = new TempEnvVar("KEYCLOAK_BACKCHANNEL_URL", null);
+
+        IReadOnlyDictionary<string, string>? capturedHeaders = null;
+        var (prismContext, _) = BuildPrismContextWithHeaderCapture(
+            OidcAuthority, ClientId,
+            headers => capturedHeaders = headers);
+
+        await prismContext.GetAuthorizationHeaderAsync();
+
+        capturedHeaders.Should().BeNull(
+            "no forwarding headers must be passed on the direct-to-public path");
+    }
+
+    /// <summary>
+    /// CRITICAL SAFETY: even when forwarding headers are passed to the backchannel refresh,
+    /// the X-Forwarded-Proto value must be derived from the configured OidcAuthority scheme
+    /// (https), never from the backchannel base URL scheme (http). Using the backchannel
+    /// scheme would produce an http forwarding header, which defeats the purpose of the fix
+    /// and could allow Keycloak to issue tokens with an http issuer.
+    /// </summary>
+    [Fact]
+    public async Task RefreshTokenAsync_ForwardingHeaders_UseAuthorityScheme_NotBackchannelScheme()
+    {
+        const string httpBackchannel = "http://localhost:8080"; // backchannel is always HTTP
+        using var envDev = new TempEnvVar("ASPNETCORE_ENVIRONMENT", "Development");
+        using var envBc = new TempEnvVar("KEYCLOAK_BACKCHANNEL_URL", httpBackchannel);
+
+        IReadOnlyDictionary<string, string>? capturedHeaders = null;
+        var (prismContext, _) = BuildPrismContextWithHeaderCapture(
+            OidcAuthority, ClientId,  // OidcAuthority is https://...
+            headers => capturedHeaders = headers);
+
+        await prismContext.GetAuthorizationHeaderAsync();
+
+        capturedHeaders.Should().NotBeNull();
+        capturedHeaders!["X-Forwarded-Proto"].Should().Be("https",
+            "the X-Forwarded-Proto value must come from OidcAuthority (https), not the backchannel base (http)");
+        capturedHeaders["X-Forwarded-Proto"].Should().NotBe("http",
+            "passing X-Forwarded-Proto: http would make Keycloak compute an http issuer, reproducing the bug");
+    }
+
+    /// <summary>
+    /// Builds a PrismContext wired for an expired-token-then-refresh scenario, capturing
+    /// the <c>requestHeaders</c> argument passed to <see cref="IPrismTokenRefreshService.RefreshAsync"/>
+    /// so tests can assert which forwarding headers were (or were not) included.
+    /// </summary>
+    private static (PrismContext prismContext, Mock<IPrismTokenRefreshService> tokenRefreshService)
+        BuildPrismContextWithHeaderCapture(
+            string oidcAuthority, string clientId,
+            Action<IReadOnlyDictionary<string, string>?> onHeaders)
+    {
+        var props = new AuthenticationProperties();
+        props.StoreTokens(new[]
+        {
+            new AuthenticationToken { Name = "refresh_token", Value = "refresh-token" }
+        });
+
+        var principal = CreateKeycloakPrincipal(oidcAuthority, clientId);
+        var ticket = new AuthenticationTicket(principal, props, "PrismMemberCookie");
+        var authResult = AuthenticateResult.Success(ticket);
+
+        var services = new ServiceCollection()
+            .AddSingleton<IAuthenticationService>(new StubAuthService(authResult))
+            .BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext { RequestServices = services };
+        var accessor = new HttpContextAccessor { HttpContext = httpContext };
+
+        var vault = new Mock<ISecretVaultService>();
+        vault.Setup(v => v.ResolveSecretAsync(PrismSecretProviderNames.Inline, ClientSecret))
+            .ReturnsAsync(ClientSecret);
+
+        var tokenRefreshService = new Mock<IPrismTokenRefreshService>();
+        tokenRefreshService
+            .Setup(t => t.RefreshAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+            .Callback<string, IReadOnlyDictionary<string, string>, CancellationToken, IReadOnlyDictionary<string, string>?>(
+                (_, _, _, headers) => onHeaders(headers))
+            .ReturnsAsync(new TokenRefreshResult(true, "new-access-token", "new-refresh-token", 3600));
+
+        var prismContext = new PrismContext(accessor, vault.Object, tokenRefreshService.Object)
+        {
+            CurrentTenant = new PrismTenant
+            {
+                OidcAuthority = oidcAuthority,
+                OidcClientId = clientId,
+                OidcClientSecretProvider = PrismSecretProviderNames.Inline,
+                OidcClientSecretReference = ClientSecret
+            }
+        };
+
+        return (prismContext, tokenRefreshService);
     }
 
     // ──────────────────────────────────────────────────────────────────────────────

--- a/src/UmbracoPrism.Core.Tests/BiometricControllerTests.cs
+++ b/src/UmbracoPrism.Core.Tests/BiometricControllerTests.cs
@@ -498,7 +498,7 @@ public class BiometricControllerTests
 
         var refreshMock = new Mock<IPrismTokenRefreshService>();
         refreshMock
-            .Setup(s => s.RefreshAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.RefreshAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>(), It.IsAny<IReadOnlyDictionary<string, string>?>()))
             .ReturnsAsync(refreshResult ?? new TokenRefreshResult(true, "new-access-token", "new-refresh-token", 3600));
 
         var vaultMock = new Mock<ISecretVaultService>();
@@ -596,7 +596,8 @@ public class BiometricControllerTests
                 p["client_secret"] == "client-secret-value" &&
                 p["grant_type"] == "refresh_token" &&
                 p["refresh_token"] == "stored-entra-refresh-token"),
-            It.IsAny<CancellationToken>()),
+            It.IsAny<CancellationToken>(),
+            It.IsAny<IReadOnlyDictionary<string, string>?>()),
             Times.Once);
     }
 
@@ -834,7 +835,8 @@ public class BiometricControllerTests
         refreshMock.Verify(s => s.RefreshAsync(
             It.IsAny<string>(),
             It.IsAny<IReadOnlyDictionary<string, string>>(),
-            It.IsAny<CancellationToken>()),
+            It.IsAny<CancellationToken>(),
+            It.IsAny<IReadOnlyDictionary<string, string>?>()),
             Times.Never);
     }
 

--- a/src/UmbracoPrism.Core.Tests/LocalhostGenericOidcRegressionTests.cs
+++ b/src/UmbracoPrism.Core.Tests/LocalhostGenericOidcRegressionTests.cs
@@ -167,8 +167,9 @@ public class LocalhostGenericOidcRegressionTests : IDisposable
             .Setup(t => t.RefreshAsync(
                 It.IsAny<string>(),
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, IReadOnlyDictionary<string, string>, CancellationToken>((_, form, _) =>
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+            .Callback<string, IReadOnlyDictionary<string, string>, CancellationToken, IReadOnlyDictionary<string, string>?>((_, form, _, _) =>
                 capturedFormData = form)
             .ReturnsAsync(new TokenRefreshResult(true, "new-access-token", "new-refresh-token", 3600));
 
@@ -223,8 +224,9 @@ public class LocalhostGenericOidcRegressionTests : IDisposable
             .Setup(t => t.RefreshAsync(
                 It.IsAny<string>(),
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, IReadOnlyDictionary<string, string>, CancellationToken>((endpoint, _, _) =>
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+            .Callback<string, IReadOnlyDictionary<string, string>, CancellationToken, IReadOnlyDictionary<string, string>?>((endpoint, _, _, _) =>
                 capturedEndpoint = endpoint)
             .ReturnsAsync(new TokenRefreshResult(true, "new-access-token", "new-refresh-token", 3600));
 
@@ -284,7 +286,7 @@ public class LocalhostGenericOidcRegressionTests : IDisposable
 
         header.Should().BeNull("because refresh should fail closed when secret is unavailable");
         tokenRefreshService.Verify(
-            t => t.RefreshAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>()),
+            t => t.RefreshAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<CancellationToken>(), It.IsAny<IReadOnlyDictionary<string, string>?>()),
             Times.Never,
             "because refresh should not be attempted without a valid client secret");
     }

--- a/src/UmbracoPrism.Core.Tests/PrismContextTests.cs
+++ b/src/UmbracoPrism.Core.Tests/PrismContextTests.cs
@@ -96,7 +96,8 @@ public class PrismContextTests
             .Setup(t => t.RefreshAsync(
                 "https://localhost:8443/realms/prism-dev/protocol/openid-connect/token",
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                httpContext.RequestAborted))
+                httpContext.RequestAborted,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
             .ReturnsAsync(new TokenRefreshResult(true, "refreshed-access-token", "refreshed-refresh-token", 3600));
 
         var prismContext = new PrismContext(accessor, vault.Object, tokenRefreshService.Object)
@@ -118,7 +119,8 @@ public class PrismContextTests
             t => t.RefreshAsync(
                 "https://localhost:8443/realms/prism-dev/protocol/openid-connect/token",
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                httpContext.RequestAborted),
+                httpContext.RequestAborted,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()),
             Times.Once);
     }
 
@@ -156,7 +158,8 @@ public class PrismContextTests
             .Setup(t => t.RefreshAsync(
                 "https://localhost:8443/realms/prism-dev/protocol/openid-connect/token",
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                httpContext.RequestAborted))
+                httpContext.RequestAborted,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
             .ReturnsAsync(new TokenRefreshResult(true, "fresh-post-restart-access-token", "fresh-refresh-token", 3600));
 
         var prismContext = new PrismContext(accessor, vault.Object, tokenRefreshService.Object)
@@ -178,7 +181,8 @@ public class PrismContextTests
             t => t.RefreshAsync(
                 "https://localhost:8443/realms/prism-dev/protocol/openid-connect/token",
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                httpContext.RequestAborted),
+                httpContext.RequestAborted,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()),
             Times.Once);
     }
 
@@ -212,7 +216,8 @@ public class PrismContextTests
             .Setup(t => t.RefreshAsync(
                 "https://localhost:8443/realms/prism-dev/protocol/openid-connect/token",
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                httpContext.RequestAborted))
+                httpContext.RequestAborted,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
             .ReturnsAsync(new TokenRefreshResult(true, "recovered-access-token", "fresh-refresh-token", 3600));
 
         var prismContext = new PrismContext(accessor, vault.Object, tokenRefreshService.Object)
@@ -234,7 +239,8 @@ public class PrismContextTests
             t => t.RefreshAsync(
                 "https://localhost:8443/realms/prism-dev/protocol/openid-connect/token",
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                httpContext.RequestAborted),
+                httpContext.RequestAborted,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()),
             Times.Once);
     }
 
@@ -318,7 +324,8 @@ public class PrismContextTests
             t => t.RefreshAsync(
                 It.IsAny<string>(),
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyDictionary<string, string>?>()),
             Times.Never);
     }
 
@@ -354,7 +361,8 @@ public class PrismContextTests
             .Setup(t => t.RefreshAsync(
                 It.IsAny<string>(),
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                cancellation.Token))
+                cancellation.Token,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
             .ReturnsAsync(new TokenRefreshResult(true, "new-access-token", "new-refresh-token", 3600));
 
         var prismContext = new PrismContext(accessor, vault.Object, tokenRefreshService.Object)
@@ -375,7 +383,8 @@ public class PrismContextTests
             t => t.RefreshAsync(
                 "https://tenant-a.ciamlogin.com/tenant-a/oauth2/v2.0/token",
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                cancellation.Token),
+                cancellation.Token,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()),
             Times.Once);
     }
 
@@ -487,8 +496,9 @@ public class PrismContextTests
             .Setup(t => t.RefreshAsync(
                 "https://localhost:8443/realms/prism-dev/protocol/openid-connect/token",
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                httpContext.RequestAborted))
-            .Callback<string, IReadOnlyDictionary<string, string>, CancellationToken>((_, form, _) => postedForm = form)
+                httpContext.RequestAborted,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+            .Callback<string, IReadOnlyDictionary<string, string>, CancellationToken, IReadOnlyDictionary<string, string>?>((_, form, _, _) => postedForm = form)
             .ReturnsAsync(new TokenRefreshResult(true, "new-access-token", "new-refresh-token", 3600));
 
         var prismContext = new PrismContext(accessor, vault.Object, tokenRefreshService.Object)
@@ -554,7 +564,8 @@ public class PrismContextTests
             t => t.RefreshAsync(
                 It.IsAny<string>(),
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
-                It.IsAny<CancellationToken>()),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyDictionary<string, string>?>()),
             Times.Never);
     }
 

--- a/src/UmbracoPrism.Core/Models/PrismContext.cs
+++ b/src/UmbracoPrism.Core/Models/PrismContext.cs
@@ -112,6 +112,7 @@ public class PrismContext(
         string clientId;
         string clientSecret;
         string scope;
+        IReadOnlyDictionary<string, string>? backchannelForwardingHeaders = null;
 
         if (!string.IsNullOrWhiteSpace(CurrentTenant.OidcAuthority))
         {
@@ -128,6 +129,14 @@ public class PrismContext(
             // the public Keycloak URL (*.app.github.dev). When KEYCLOAK_BACKCHANNEL_URL is set
             // AND the environment is Development, rewrite the token endpoint host to the internal
             // backchannel URL before POSTing the refresh-token grant.
+            //
+            // We also include X-Forwarded-Proto / X-Forwarded-Host headers so that Keycloak
+            // (running with --proxy-headers xforwarded) computes its issuer URL as the public
+            // HTTPS authority rather than the raw HTTP localhost URL. Without these headers
+            // Keycloak derives the issuer as http://... which mismatches the https://... iss
+            // claim embedded in the refresh token (originally issued through the YARP proxy),
+            // causing Keycloak to return invalid_grant.
+            //
             // Transport rewrite ONLY: issuer/audience validation on the returned tokens remains
             // strict against the public OidcAuthority. Outside Development or when the env var
             // is absent, this block is never entered — zero behaviour change for production.
@@ -141,6 +150,15 @@ public class PrismContext(
                 var oidcPath = new Uri(CurrentTenant.OidcAuthority!.TrimEnd('/')).AbsolutePath.TrimEnd('/');
                 tokenEndpoint = $"{backchannelBase.TrimEnd('/')}{oidcPath}/protocol/openid-connect/token";
                 Console.WriteLine($"[PRISM] RefreshTokenAsync: rewriting token endpoint to backchannel → {tokenEndpoint}");
+
+                // Derive X-Forwarded-* values from the public OidcAuthority so Keycloak
+                // computes its canonical issuer as https://<public-host>/realms/prism-dev.
+                var authorityUri = new Uri(CurrentTenant.OidcAuthority!.TrimEnd('/'));
+                backchannelForwardingHeaders = new Dictionary<string, string>
+                {
+                    ["X-Forwarded-Proto"] = authorityUri.Scheme,
+                    ["X-Forwarded-Host"]  = authorityUri.Host
+                };
             }
 
             clientId = CurrentTenant.OidcClientId;
@@ -189,7 +207,7 @@ public class PrismContext(
             formParameters["scope"] = scope;
         }
 
-        var result = await tokenRefreshService.RefreshAsync(tokenEndpoint, formParameters, context.RequestAborted);
+        var result = await tokenRefreshService.RefreshAsync(tokenEndpoint, formParameters, context.RequestAborted, backchannelForwardingHeaders);
 
         if (!result.Success || result.AccessToken == null)
         {

--- a/src/UmbracoPrism.Core/Services/IPrismTokenRefreshService.cs
+++ b/src/UmbracoPrism.Core/Services/IPrismTokenRefreshService.cs
@@ -13,11 +13,17 @@ public interface IPrismTokenRefreshService
     /// <param name="tokenEndpoint">Absolute token endpoint URL for the tenant authority.</param>
     /// <param name="formParameters">Form-encoded parameters required by the token endpoint.</param>
     /// <param name="cancellationToken">Cancellation token for the outbound refresh operation.</param>
+    /// <param name="requestHeaders">
+    /// Optional HTTP headers added to the outbound request (e.g. <c>X-Forwarded-Proto</c>,
+    /// <c>X-Forwarded-Host</c>). Used when the token endpoint has been rewritten to an internal
+    /// backchannel address so the upstream server can still derive the correct public issuer URL.
+    /// </param>
     /// <returns>The parsed refresh result including success state and returned token values.</returns>
     Task<TokenRefreshResult> RefreshAsync(
         string tokenEndpoint,
         IReadOnlyDictionary<string, string> formParameters,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        IReadOnlyDictionary<string, string>? requestHeaders = null);
 }
 
 /// <summary>Result of a token refresh request.</summary>

--- a/src/UmbracoPrism.Core/Services/PrismTokenRefreshService.cs
+++ b/src/UmbracoPrism.Core/Services/PrismTokenRefreshService.cs
@@ -96,7 +96,8 @@ public sealed class PrismTokenRefreshService : IPrismTokenRefreshService
     public async Task<TokenRefreshResult> RefreshAsync(
         string tokenEndpoint,
         IReadOnlyDictionary<string, string> formParameters,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        IReadOnlyDictionary<string, string>? requestHeaders = null)
     {
         if (string.IsNullOrWhiteSpace(tokenEndpoint))
         {
@@ -114,10 +115,19 @@ public sealed class PrismTokenRefreshService : IPrismTokenRefreshService
 
             response = await pipeline.ExecuteAsync(async ct =>
             {
-                // Re-create content on every attempt: FormUrlEncodedContent is single-use.
+                // Re-create request + content on every attempt: FormUrlEncodedContent is single-use.
                 using var content = new FormUrlEncodedContent(
                     formParameters.Select(p => KeyValuePair.Create<string?, string?>(p.Key, p.Value)));
-                return await client.PostAsync(normalizedEndpoint, content, ct);
+                using var request = new HttpRequestMessage(HttpMethod.Post, normalizedEndpoint)
+                {
+                    Content = content
+                };
+                if (requestHeaders != null)
+                {
+                    foreach (var (name, value) in requestHeaders)
+                        request.Headers.TryAddWithoutValidation(name, value);
+                }
+                return await client.SendAsync(request, ct);
             }, cancellationToken);
         }
         catch (BrokenCircuitException)


### PR DESCRIPTION
## Working as Blathers (backend/auth)

## Summary

Fixes a persistent `invalid_grant` 401 in the Codespaces "Call Mock Business App API" demo when the access token expires and a refresh is attempted.

## Root Cause

Keycloak 26 with `--proxy-headers xforwarded` uses `X-Forwarded-Proto` to derive its canonical issuer URL scheme. The backchannel refresh POST goes to `http://localhost:8080` with no forwarding headers, so Keycloak computes its issuer as `http://…`. But the stored refresh token's `iss` JWT claim was `https://…` (set during initial login through YARP, which forwards proper headers). Keycloak detects the scheme mismatch on the grant request → `invalid_grant`.

The initial authorization code exchange was unaffected because codes are opaque DB lookups (no `iss` claim to compare).

**Diagnostic commands to confirm root cause:**
```bash
curl -s http://localhost:8080/realms/prism-dev/.well-known/openid-configuration | jq .issuer
curl -s https://${CODESPACE_NAME}-8443.app.github.dev/realms/prism-dev/.well-known/openid-configuration | jq .issuer
# If these differ (http vs https), root cause confirmed
```

## Changes

| File | Change |
|------|--------|
| `IPrismTokenRefreshService.cs` | Added optional `requestHeaders` param to `RefreshAsync` |
| `PrismTokenRefreshService.cs` | Switched to `HttpRequestMessage`/`SendAsync` so per-request headers apply on each Polly retry |
| `PrismContext.cs` | Derives `X-Forwarded-Proto`+`X-Forwarded-Host` from `OidcAuthority` when backchannel active; passes to `RefreshAsync` |
| `BackchannelRewriteTests.cs` | Group E — 3 new regression tests |
| Existing test files | Updated mock setups to include new 4th param |

## Security

- `ValidIssuer` in Prism's JWT validation remains `tenant.OidcAuthority` (public HTTPS URL) — unchanged
- Forwarding headers only affect Keycloak's grant-time issuer computation
- Headers derived from `OidcAuthority` (HTTPS), **not** from backchannel base URL (HTTP) — prevents reproducing the bug with an `http` header
- Production and non-backchannel paths are unaffected (parameter defaults to `null`)

## Tests

645 passed, 0 failed, 0 skipped.