### PR TITLE
fix(codespaces): use dynamic endpoint discovery for BusinessApp backchannel

### DIFF
--- a/.squad/agents/blathers/history.md
+++ b/.squad/agents/blathers/history.md
@@ -2,7 +2,37 @@
 
 **Agent:** Backend specialist shipping Codespaces URL derivation fixes, backchannel rewrites for JWKS/token-refresh, and security analysis for auth isolation.
 
-**Recent focus:** Aspire dashboard Codespaces access, authentication diagnostics, runtime stale-code diagnosis, backchannel OIDC validation.
+**Recent focus:** Aspire dashboard Codespaces access, authentication diagnostics, runtime stale-code diagnosis, backchannel OIDC validation, dynamic endpoint discovery.
+
+---
+
+## 2026-05-03: BusinessApp Backchannel Timeout Fix — Dynamic Endpoint Discovery
+
+**Status:** ✅ Implemented (PR #49)
+
+**Problem:**
+Browser-facing downstream API demo button shows correct public URL (fixed in PR #48), but server-side API call times out after 10 seconds in Codespaces. MockBusinessApp admin page loads successfully, proving the app is running.
+
+**Root Cause:**
+AppHost hardcoded `BUSINESSAPP_BACKCHANNEL_URL=http://localhost:5163` (line 142), assuming port 5163 is always correct. However, Aspire may assign ephemeral ports or not bind the HTTP endpoint at the expected address in Codespaces, causing the hardcoded URL to become unreachable.
+
+**Solution:**
+Changed to `businessApp.GetEndpoint("http")` for dynamic endpoint discovery, matching the pattern already used successfully for Keycloak (line 134). This ensures the backchannel URL points to the actual runtime HTTP endpoint regardless of port assignment.
+
+**Implementation:**
+- AppHost/Program.cs: Use `businessApp.GetEndpoint("http")` instead of hardcoded URL
+- DashboardLocalEndpointsValidationTests.cs: Updated test contract to validate dynamic discovery pattern
+- Added explanatory comment about Aspire ephemeral port assignment
+
+**Test Results:**
+- All 674 Core tests pass
+- Test validates the new dynamic discovery pattern with explanatory "because" clause
+
+**Operational Recovery:**
+After merging PR #49, restart the Aspire AppHost in Codespaces. The backchannel will automatically resolve to the correct runtime endpoint, fixing the timeout.
+
+**Key Insight:**
+Containers (like Keycloak) and projects (like MockBusinessApp) both work with `GetEndpoint("http")` for dynamic discovery. The previous failure with `GetEndpoint("https")` was specific to service discovery URLs on HTTPS endpoints — HTTP endpoints return plain `http://localhost:{port}` URLs that work from plain HttpClient.
 
 ---
 
@@ -61,3 +91,36 @@ Use HTTPS port 17214 directly in Codespaces. Update `.devcontainer/devcontainer.
 ## Earlier Sessions
 
 Full history archived to `history-archive.md` (prior to 2026-05-03).
+
+---
+date: 2026-05-03T19:40:50Z
+status: complete
+area: implementation, orchestration, aspire-endpoints
+---
+
+# Session Coordination: Downstream API Timeout — Dynamic Endpoint Discovery Fix
+
+## Team Outcome
+
+Parallel investigation with Tangy (Test) identified and fixed downstream API timeout root cause.
+
+**Root Cause:** AppHost hardcoded `BUSINESSAPP_BACKCHANNEL_URL=http://localhost:5163` instead of using Aspire's dynamic endpoint discovery.
+
+**Implementation:** Changed to `businessApp.GetEndpoint("http")` pattern (commit `2a46494`), matching the proven Keycloak backchannel approach.
+
+## Implementation Details
+
+1. **AppHost change:** Line 142 now uses `businessApp.GetEndpoint("http")` for runtime discovery
+2. **Test contract:** Added regression coverage in `DashboardLocalEndpointsValidationTests`
+3. **Why HTTP works:** Returns plain `http://localhost:{port}` URL compatible with bare HttpClient
+4. **Why HTTPS doesn't:** Returns service discovery URL requiring Aspire SDK extensions
+
+## PR Status
+
+PR #49 ready for merge. After merge, restart Aspire AppHost in Codespaces — backchannel will resolve to correct runtime endpoint.
+
+## Coordination
+
+- Decisions archived to `.squad/decisions.md`
+- Orchestration log: `.squad/orchestration-log/2026-05-03T18:40:50Z-blathers.md`
+- Session log: `.squad/log/2026-05-03T18:40:50Z-downstream-timeout-diagnosis.md`

--- a/.squad/agents/tangy/history.md
+++ b/.squad/agents/tangy/history.md
@@ -140,3 +140,152 @@ The Playwright test validates this at the user experience level — if the dashb
 
 **Behavior-level assertions**: Prefer testing what the user sees over implementation details. The Playwright test doesn't care *how* the URL is transformed, only that the displayed URL is publicly accessible.
 
+
+---
+
+## 2026-05-03: Downstream API Timeout — Hardcoded Backchannel Port Issue
+
+**Timestamp:** 2026-05-03T19:40:50.786+01:00  
+**Status:** 🔍 Diagnosed (architectural gap identified, handed to Blathers)
+
+### Problem
+
+User reports: After the URL transformation fix (showing public 7245 URL correctly), the browser call to "Call Mock Business App API" still times out after 10 seconds, even though the MockBusinessApp admin page is reachable.
+
+### Investigation
+
+The URL transformation fix (commits `6774c55`, `2ebec5a`) **is working correctly** - it transforms the internal `http://localhost:5163` backchannel URL to the public Codespaces URL in browser-facing responses.
+
+**But:** The actual server-to-server call from TestSite to MockBusinessApp is timing out because AppHost line 142 hardcodes:
+
+```csharp
+testsite.WithEnvironment("BUSINESSAPP_BACKCHANNEL_URL", "http://localhost:5163");
+```
+
+This assumes port 5163 is always correct, but Aspire may assign ephemeral ports in Codespaces. The correct pattern (already used for Keycloak at line 134) is:
+
+```csharp
+testsite.WithEnvironment("BUSINESSAPP_BACKCHANNEL_URL", businessApp.GetEndpoint("http"));
+```
+
+This gets the **actual runtime HTTP endpoint** that Aspire assigned.
+
+### Behavioral Contract Violation
+
+**Contract:** Server-to-server API calls must complete within the configured timeout (10 seconds)
+
+**Current behavior:**
+- TestSite attempts to call hardcoded `http://localhost:5163/api/backoffice/me`
+- Port is unreachable or wrong
+- Request times out after 10 seconds
+- Controller returns "Timeout" response (statusCode 0)
+- Browser displays: "We could not reach the Mock Business App..."
+
+**Expected behavior:**
+- TestSite calls MockBusinessApp's actual runtime HTTP endpoint
+- Request completes successfully (200 OK)
+- Browser displays: "Mock Business App responded successfully."
+
+### Test Coverage Analysis
+
+**Existing tests:**
+- ✅ `DownstreamDemo_ReturnsPublicUrl_WhenBackchannelUrlIsUsedForTransport` validates URL transformation with stub handler
+- ✅ Playwright `callBusinessAppApi()` validates the end-to-end flow including button click, status badge, response body
+- ❌ **Test gap:** The Playwright test runs against a live Aspire stack, so it SHOULD catch this bug
+- ❌ **BUT:** The test may be passing because it's running in a local dev environment where port 5163 IS correct, not in Codespaces where Aspire assigns ephemeral ports
+
+**Smallest regression test surface:**
+
+The existing Playwright test `callBusinessAppApi()` (localhost-auth-session.spec.ts, line 150-186) **should fail** if the backchannel is wrong:
+
+```typescript
+await expect(statusBadge).toHaveText(/200 OK/, { timeout: 120_000 });
+```
+
+If the timeout happens, this assertion should fail with:
+```
+Expected API call to succeed with 200 OK, but got:
+Status: Timeout
+```
+
+### Recommended Fix (Handed to Blathers)
+
+**Change AppHost line 142:**
+
+FROM:
+```csharp
+testsite.WithEnvironment("BUSINESSAPP_BACKCHANNEL_URL", "http://localhost:5163");
+```
+
+TO:
+```csharp
+testsite.WithEnvironment("BUSINESSAPP_BACKCHANNEL_URL", businessApp.GetEndpoint("http"));
+```
+
+This ensures TestSite uses the actual runtime HTTP endpoint, matching the Keycloak pattern.
+
+**Also fix failing unit test `AppHost_ConfiguresBusinessAppBackchannel_ForCodespacesServerCalls` at line 302:**
+
+The test looks for `.WithEnvironment(...)` but the actual code has `testsite.WithEnvironment(...)`. Update the assertion to:
+
+```csharp
+program.Should().Contain("BUSINESSAPP_BACKCHANNEL_URL");
+program.Should().Contain("businessApp.GetEndpoint(\"http\")");
+```
+
+### Why I Stayed Read-Only
+
+This is an **AppHost configuration issue**, not a test-only fix. The architectural pattern (hardcoded port vs runtime endpoint) belongs to Blathers' domain. The test would pass if the configuration were correct.
+
+The fix is obvious (use `.GetEndpoint("http")`), but implementing it requires:
+1. Understanding Aspire endpoint semantics
+2. Verifying MockBusinessApp exposes HTTP endpoint correctly
+3. Validating behavior in Codespaces environment
+4. Potentially adjusting other backchannel-related config
+
+This is infrastructure work, not test surface work.
+
+### Learnings
+
+**Hardcoded ports vs runtime endpoints:** When using Aspire, always prefer `.GetEndpoint("protocol")` over hardcoded `localhost:port` strings. Aspire may assign ephemeral ports, especially in containerized/Codespaces environments.
+
+**Test coverage vs environment coverage:** A Playwright test running against localhost may pass even when Codespaces fails, if the localhost environment happens to match the hardcoded assumptions. Environment-specific failures require environment-specific test runs.
+
+**URL transformation ≠ endpoint reachability:** The URL transformation fix solved the **display** problem (showing public URLs to browsers), but didn't solve the **transport** problem (server reaching the backchannel). These are separate concerns that both need fixing.
+
+### Decision Recorded
+
+`.squad/decisions/inbox/tangy-downstream-timeout.md` — full diagnosis and fix recommendation
+
+
+---
+date: 2026-05-03T19:40:50Z
+status: complete
+area: testing, orchestration
+---
+
+# Session Coordination: Downstream Timeout Root Cause Diagnosis
+
+## Team Outcome
+
+Two-agent parallel investigation identified root cause of downstream API timeout:
+
+**Tangy (Diagnosis):**
+- ✅ Confirmed PR #48 URL transformation fix was correct
+- ✅ Isolated root cause: AppHost hardcoded backchannel port instead of using Aspire dynamic discovery
+- ✅ Test gap identified: Playwright test doesn't run in full Aspire + Codespaces environment
+
+**Blathers (Implementation):**
+- ✅ Implemented fix: Changed to `businessApp.GetEndpoint("http")` pattern
+- ✅ Updated regression test: `DashboardLocalEndpointsValidationTests.AppHost_ConfiguresBusinessAppBackchannel_ForCodespacesServerCalls`
+- ✅ PR #49 ready for merge and Aspire restart
+
+## Key Finding
+
+Aspire port assignment may differ from launchSettings.json in Codespaces. Dynamic endpoint discovery is the only reliable pattern for backchannel URLs.
+
+## Coordination
+
+- Decisions archived to `.squad/decisions.md`
+- Orchestration logs written to `.squad/orchestration-log/`
+- Session log: `.squad/log/2026-05-03T18:40:50Z-downstream-timeout-diagnosis.md`

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -490,3 +490,217 @@ Local `.squad/` history files remained uncommitted (not mixed into product PR), 
 ## Consistency with PR #47
 
 This approach is consistent with PR #47 merge strategy (also used `--merge` to preserve dashboard + auth fix commits). Establishing this as the standard practice for PRs with multiple concerns.
+---
+date: 2026-05-03T19:40:50.786+01:00
+author: Blathers
+status: implemented
+area: codespaces, aspire-orchestration, backchannel-urls
+---
+
+# Use Dynamic Endpoint Discovery for Aspire Project Backchannels
+
+## Context
+
+The downstream API demo was timing out in Codespaces after the URL transformation fix (PR #48). The browser-facing URL was correct (showing the public Codespaces URL), but the server-side API call was timing out after 10 seconds.
+
+Root cause: AppHost hardcoded `BUSINESSAPP_BACKCHANNEL_URL=http://localhost:5163`, assuming port 5163 would always be correct. However, Aspire may assign ephemeral ports or not bind the HTTP endpoint at the expected address in Codespaces.
+
+## Decision
+
+**For Aspire project resources (not containers), use dynamic endpoint discovery for backchannel URLs.**
+
+Pattern:
+```csharp
+// Container resources (Keycloak) — already using dynamic discovery
+testsite.WithEnvironment("KEYCLOAK_BACKCHANNEL_URL", keycloak.GetEndpoint("http"));
+
+// Project resources (MockBusinessApp) — NOW using dynamic discovery
+testsite.WithEnvironment("BUSINESSAPP_BACKCHANNEL_URL", businessApp.GetEndpoint("http"));
+```
+
+**Do not hardcode ports** for backchannel URLs, even if they're defined in launchSettings.json. Aspire's dynamic port assignment takes precedence.
+
+## Why This Matters
+
+1. **Codespaces reliability**: Aspire's port assignment may differ from launchSettings.json in containerized environments
+2. **Consistency**: Matches the Keycloak backchannel pattern which works reliably
+3. **Maintainability**: Single source of truth for endpoint addresses (Aspire's runtime discovery)
+
+## Why GetEndpoint("http") Works for Projects
+
+**Historical context**: An earlier attempt used `businessApp.GetEndpoint("https")` and failed because it returned a service discovery URL that didn't resolve from plain HttpClient.
+
+**Why HTTP works**: The HTTP endpoint returns a plain `http://localhost:{port}` URL (not a service discovery URL), which works from plain HttpClient without Aspire service discovery extensions.
+
+## Test Contract
+
+Updated `DashboardLocalEndpointsValidationTests.AppHost_ConfiguresBusinessAppBackchannel_ForCodespacesServerCalls`:
+
+```csharp
+program.Should().Contain(".WithEnvironment(\"BUSINESSAPP_BACKCHANNEL_URL\", businessApp.GetEndpoint(\"http\"))",
+    because: "Aspire's dynamic endpoint discovery ensures the correct HTTP port is used, " +
+             "avoiding hardcoded ports that may differ across environments or Aspire configurations");
+```
+
+This validates the dynamic discovery pattern and prevents regression to hardcoded ports.
+
+## Operational Recovery
+
+**After merging PR #49**: Restart the Aspire AppHost in Codespaces. The backchannel will automatically resolve to the correct runtime HTTP endpoint, fixing the timeout.
+
+No database migrations, no secrets updates, no client-side changes required.
+
+## Alternatives Considered
+
+**Alternative 1: Keep hardcoded localhost:5163**  
+Rejected: Already proven to fail in Codespaces. No reason to assume port assignment will be stable.
+
+**Alternative 2: Use GetEndpoint("https")**  
+Rejected: Historical evidence (commit `ffc32c5`) shows HTTPS endpoints return service discovery URLs that don't work from plain HttpClient.
+
+**Alternative 3: Configure Aspire to force specific ports**  
+Rejected: Fights against Aspire's design. Dynamic discovery is the intended pattern.
+
+## References
+
+- Implementation: PR #49 (`squad/fix-backchannel-endpoint-discovery`)
+- Commit: `2a46494`
+- Test: `DashboardLocalEndpointsValidationTests.AppHost_ConfiguresBusinessAppBackchannel_ForCodespacesServerCalls`
+- Prior failed attempt: Commit `ffc32c5` (removed businessApp.GetEndpoint("https"))
+- History: `.squad/agents/blathers/history.md` — "BusinessApp Backchannel Timeout Fix"
+---
+date: 2026-05-03T19:40:50.786+01:00
+author: Tangy
+status: DIAGNOSED
+area: testing, codespaces, aspire-endpoints
+---
+
+# Downstream API Timeout: Hardcoded Backchannel Port vs Aspire Runtime Endpoint
+
+## Context
+
+User reports: "The downstream API demo now shows the public 7245 URL, but the browser call still times out after 10 seconds even though the Mock Business App admin page is reachable."
+
+## Investigation
+
+**What's working:**
+- ✅ URL transformation fix (commit `6774c55`, `2ebec5a`) correctly transforms internal `http://localhost:5163` to public Codespaces URL in browser-facing responses
+- ✅ Unit test `DownstreamDemo_ReturnsPublicUrl_WhenBackchannelUrlIsUsedForTransport` validates the transformation logic
+- ✅ MockBusinessApp admin page is reachable from browser (confirms app is running)
+- ✅ Playwright test validates displayed URL doesn't contain `:5163`
+
+**What's broken:**
+- ❌ Server-to-server call from TestSite to MockBusinessApp times out after 10 seconds
+- ❌ `DownstreamDemoController` line 289 timeout triggers, returns "Timeout" response to browser
+
+## Root Cause
+
+AppHost line 142 hardcodes the backchannel URL:
+
+```csharp
+if (codespaceName != null)
+    testsite.WithEnvironment("BUSINESSAPP_BACKCHANNEL_URL", "http://localhost:5163");
+```
+
+This assumes MockBusinessApp's HTTP endpoint is bound to port 5163. However:
+
+1. **Aspire may assign ephemeral ports** - the actual runtime port might not be 5163
+2. **Keycloak pattern** (line 134) uses the correct approach: `keycloak.GetEndpoint("http")` to get the actual runtime endpoint
+3. **MockBusinessApp is started with `launchProfile: "https"`** (line 97), which specifies `"applicationUrl": "https://localhost:7245;http://localhost:5163"` in launchSettings.json
+
+The hardcoded `http://localhost:5163` is fragile and doesn't work when Aspire assigns different ports in Codespaces.
+
+## Behavioral Contract Violation
+
+**Contract:** Server-to-server API calls must complete within the configured timeout (10 seconds)
+
+**Current behavior:**
+- TestSite attempts to call `http://localhost:5163/api/backoffice/me`
+- Request times out after 10 seconds
+- Controller returns "Timeout" response with statusCode 0, statusText "Timeout"
+- Browser displays: "We could not reach the Mock Business App. Check that it is running, then try again."
+
+**Expected behavior:**
+- TestSite calls MockBusinessApp's actual HTTP endpoint
+- Request completes successfully (200 OK)
+- Browser displays: "Mock Business App responded successfully."
+
+## Test Coverage Gap
+
+**Current tests:**
+- ✅ Unit tests validate URL transformation logic with stub handlers
+- ✅ Playwright test validates displayed URL format
+- ❌ **No test validates backchannel endpoint is actually reachable**
+- ❌ **No test validates AppHost backchannel configuration matches Aspire reality**
+
+**Smallest regression test surface:**
+
+The existing Playwright test `callBusinessAppApi()` (localhost-auth-session.spec.ts, line 150-186) **SHOULD** catch this bug because it:
+1. Clicks "Call Mock Business App API"
+2. Expects `#api-status-badge` to show "200 OK"
+3. Expects response body to contain tenant and role info
+
+If the backchannel times out, this test should fail with:
+```
+Expected API call to succeed with 200 OK, but got:
+Status: Timeout
+Summary: We could not reach the Mock Business App...
+Body: Request timed out after 10 seconds. Is MockBusinessApp running?
+```
+
+**Question:** Does this Playwright test run in Codespaces with Aspire? If not, that's the coverage gap.
+
+## Recommended Fix (For Blathers)
+
+Change AppHost line 142 from:
+
+```csharp
+if (codespaceName != null)
+    testsite.WithEnvironment("BUSINESSAPP_BACKCHANNEL_URL", "http://localhost:5163");
+```
+
+To:
+
+```csharp
+if (codespaceName != null)
+    testsite.WithEnvironment("BUSINESSAPP_BACKCHANNEL_URL", businessApp.GetEndpoint("http"));
+```
+
+This matches the Keycloak pattern (line 134) and ensures TestSite uses the actual runtime HTTP endpoint that Aspire assigned to MockBusinessApp.
+
+**Note:** This requires MockBusinessApp to expose an HTTP endpoint. Verify the launchProfile "https" includes both HTTPS and HTTP in applicationUrl (currently: `"https://localhost:7245;http://localhost:5163"`).
+
+## Test Fix
+
+The failing unit test `AppHost_ConfiguresBusinessAppBackchannel_ForCodespacesServerCalls` (line 302) needs updating:
+
+Current:
+```csharp
+program.Should().Contain(".WithEnvironment(\"BUSINESSAPP_BACKCHANNEL_URL\", \"http://localhost:5163\")");
+```
+
+Should be:
+```csharp
+program.Should().Contain("testsite.WithEnvironment(\"BUSINESSAPP_BACKCHANNEL_URL\", businessApp.GetEndpoint(\"http\"))");
+```
+
+Or make it more flexible:
+```csharp
+program.Should().Contain("BUSINESSAPP_BACKCHANNEL_URL");
+program.Should().Contain("businessApp.GetEndpoint(\"http\")");
+```
+
+## Why This Matters
+
+1. **Codespaces-critical:** Hardcoded localhost ports don't work reliably when Aspire assigns ephemeral ports
+2. **Consistency:** Keycloak already uses `.GetEndpoint("http")` pattern - MockBusinessApp should match
+3. **Behavioral contract:** The Playwright test should catch this, but only if it runs in the actual Codespaces + Aspire environment
+
+## References
+
+- AppHost configuration: `src/UmbracoPrism.AppHost/Program.cs` lines 134, 142
+- Controller timeout: `src/UmbracoPrism.TestSite/Controllers/DownstreamDemoController.cs` line 289
+- Keycloak pattern: AppHost line 134 (`testsite.WithEnvironment("KEYCLOAK_BACKCHANNEL_URL", keycloak.GetEndpoint("http"))`)
+- MockBusinessApp launchSettings: `src/UmbracoPrism.MockBusinessApp/Properties/launchSettings.json`
+- Playwright test: `src/UmbracoPrism.Client/tests/localhost-auth-session.spec.ts` line 150-186
+- Related decisions: `.squad/decisions.md` - "Transport URLs vs Display URLs: Separate Concerns in API Responses"

--- a/src/UmbracoPrism.AppHost/Program.cs
+++ b/src/UmbracoPrism.AppHost/Program.cs
@@ -138,8 +138,9 @@ if (codespaceName != null)
 // because the forwarded port is browser-facing and often private. Use the BusinessApp's internal
 // HTTP endpoint for server-to-server traffic; keep PrismBusinessApp__WorkflowApiBaseUrl as the
 // browser/public URL only.
+// NOTE: Aspire may assign ephemeral ports, so use GetEndpoint("http") for dynamic discovery.
 if (codespaceName != null)
-    testsite.WithEnvironment("BUSINESSAPP_BACKCHANNEL_URL", "http://localhost:5163");
+    testsite.WithEnvironment("BUSINESSAPP_BACKCHANNEL_URL", businessApp.GetEndpoint("http"));
 
 // BusinessApp also fetches Keycloak signing keys server-side for JWT Bearer validation.
 // Same backchannel fix: without this the external Keycloak URL is blocked by the

--- a/src/UmbracoPrism.Core.Tests/DashboardLocalEndpointsValidationTests.cs
+++ b/src/UmbracoPrism.Core.Tests/DashboardLocalEndpointsValidationTests.cs
@@ -299,7 +299,9 @@ public class DashboardLocalEndpointsValidationTests : IDisposable
             "UmbracoPrism.AppHost",
             "Program.cs"));
 
-        program.Should().Contain(".WithEnvironment(\"BUSINESSAPP_BACKCHANNEL_URL\", \"http://localhost:5163\")");
+        program.Should().Contain(".WithEnvironment(\"BUSINESSAPP_BACKCHANNEL_URL\", businessApp.GetEndpoint(\"http\"))",
+            because: "Aspire's dynamic endpoint discovery ensures the correct HTTP port is used, " +
+                     "avoiding hardcoded ports that may differ across environments or Aspire configurations");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

The downstream API demo times out after 10 seconds in Codespaces, even though MockBusinessApp is running and its admin page is reachable.

## Root Cause

AppHost line 142 hardcodes `BUSINESSAPP_BACKCHANNEL_URL=http://localhost:5163`, assuming port 5163 is always correct. However, Aspire may assign ephemeral ports or not expose the HTTP endpoint at the expected address in Codespaces.

## Fix

Use `businessApp.GetEndpoint("http")` for dynamic endpoint discovery, matching the pattern already used successfully for Keycloak.

## Test Results

- ✅ All 674 Core tests pass
- ✅ Updated test contract validates the dynamic discovery pattern

## Operational Recovery

After merging, restart the Aspire AppHost in Codespaces to pick up the new configuration. The backchannel will then use the actual runtime HTTP endpoint instead of the hardcoded address.

Closes #TBD (no issue number yet)