### PR TITLE
Tenant environment tokens + uSync integration

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,144 @@
+---
+description: Cut a release — infer semver bump from commits, update version files, draft CHANGELOG, and open a PR
+---
+
+Cut a release for Umbraco Prism. Follow these steps exactly:
+
+## 1. Find the last release tag
+
+```bash
+git tag --list 'v*' --sort=-version:refname | head -1
+```
+
+If no tags exist, treat all history as unreleased.
+
+## 2. Read commits since last tag
+
+```bash
+git log {last_tag}..HEAD --format="%H %s%n%b" --no-merges
+```
+
+Read both the subject line and body of each commit — the body may contain `BREAKING CHANGE:` notes.
+
+## 3. Infer the semver bump
+
+Analyse the full commit log:
+
+- **major** → any commit with `BREAKING CHANGE` in the body, or `!` after the type (e.g. `feat!:`, `fix!:`)
+- **minor** → any `feat:` commit (no breaking change)
+- **patch** → `fix:`, `perf:`, `docs:`, `chore:`, `refactor:`, `test:`, or no conventional prefix
+
+Take the highest signal found. If no conventional commit signals are present, default to **patch** and note the uncertainty when reporting.
+
+Compute the new version by incrementing the appropriate component of the current version and resetting lower components to zero.
+
+## 4. Announce the plan
+
+Before making any changes, tell the user:
+- The last tag and number of commits found
+- The inferred bump type and why (which commit(s) drove it)
+- The new version number (`vX.Y.Z`)
+
+Ask for confirmation before proceeding: **"Shall I cut vX.Y.Z as a {bump type} release?"**
+
+Wait for a yes/go-ahead before continuing.
+
+## 5. Create a release branch
+
+```bash
+git checkout -b release/v{new_version}
+```
+
+## 6. Update version files
+
+Keep these two files in sync — update both:
+
+- `src/UmbracoPrism.Core/UmbracoPrism.Core.csproj` → `<Version>{new_version}</Version>`
+- `src/UmbracoPrism.Client/package.json` → `"version": "{new_version}"`
+
+## 7. Draft the CHANGELOG entry
+
+Write a new section at the **top** of `CHANGELOG.md` (immediately after the `# Changelog` heading and intro paragraph), using this format:
+
+```markdown
+## [v{new_version}] — {YYYY-MM-DD}
+
+### Breaking Changes
+- ...
+
+### New Features
+- ...
+
+### Bug Fixes & Improvements
+- ...
+
+---
+```
+
+Omit any section that has no entries.
+
+**Drafting standards — apply every one:**
+- **Plain English:** No commit hashes, no internal references, no jargon
+- **Developer-first:** Each bullet answers "what changed and why does it matter to me?"
+- **Active voice, present tense:** "Adds support for X", "Fixes Y when Z"
+- **One change per bullet**, short sentences, no walls of text
+- **No filler:** Skip pure internal chore entries (dependency bumps, CI tweaks) unless they affect developers using the package
+- Re-read the entry as if you are a developer encountering it cold. If anything is unclear, rewrite it.
+
+## 8. Run pre-release checks
+
+Run these in order and stop if either fails:
+
+```bash
+npm run check:marketplace
+```
+```bash
+dotnet test UmbracoPrism.sln -c Release --filter FullyQualifiedName~UmbracoPrism.Core.Tests
+```
+
+Fix any failures before proceeding.
+
+## 9. Show the CHANGELOG draft
+
+Print the full draft CHANGELOG entry and say:
+
+> "Here's the draft for v{new_version}. Let me know if you want to edit anything, or say go ahead to commit."
+
+Wait for approval or edits. Apply any changes the user requests, then re-show the affected section before committing.
+
+## 10. Commit
+
+Stage only these files:
+
+```bash
+git add src/UmbracoPrism.Core/UmbracoPrism.Core.csproj src/UmbracoPrism.Client/package.json CHANGELOG.md
+git commit -m "chore: release v{new_version}"
+```
+
+## 11. Push and open a PR
+
+```bash
+git push -u origin release/v{new_version}
+gh pr create \
+  --title "Release: v{new_version}" \
+  --body "..."
+```
+
+PR body should include:
+- The bump type and what drove it
+- The full release notes (copy from the CHANGELOG section)
+- The post-merge tagging instruction (see step 12)
+
+## 12. Report and remind
+
+Return the PR URL and remind the user:
+
+> After the PR is merged to main, tag the merge commit to trigger the NuGet publish:
+>
+> ```bash
+> git checkout main && git pull
+> git tag v{new_version}
+> git push origin v{new_version}
+> ```
+>
+> This triggers `package-release.yml` which builds, packs, and publishes the NuGet package.

--- a/.gitignore
+++ b/.gitignore
@@ -523,3 +523,6 @@ src/UmbracoPrism.TestSite/appsettings.Local.json
 # Supply real Entra tenant/client IDs and member emails here.
 # See src/UmbracoPrism.MockBusinessApp/README.md for setup instructions.
 src/UmbracoPrism.MockBusinessApp/appsettings.Local.json
+
+# uSync export files — environment-specific, not source artefacts.
+uSync/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,181 @@
+# Umbraco Prism — Project Guide for Claude Code
+
+## What this is
+
+Umbraco Prism is an Umbraco v17 package that adds multi-tenant OIDC authentication, runtime branding, a GDS-style workflow engine with a visual editor, and native mobile app generation. The repo is a mono-repo containing the package itself plus a full demo stack (TestSite, MockBusinessApp, Keycloak) orchestrated via .NET Aspire.
+
+Solo developer project. Work directly on `main` for simple fixes; use feature branches + PRs for substantive code changes.
+
+---
+
+## Projects
+
+| Project | Purpose |
+|---|---|
+| `UmbracoPrism.Core` | The publishable Umbraco package — controllers, middleware, auth, services, tag helpers, views |
+| `UmbracoPrism.Shared` | Shared models used by both Core and demo apps — `WorkflowDefinitionFile`, `WorkflowResponseEnvelope`, etc. |
+| `UmbracoPrism.WorkflowRuntime` | Workflow state-machine engine — queue routing, gateway evaluation, instance persistence |
+| `UmbracoPrism.WorkflowEditor` | Razor Class Library hosting the compiled workflow editor web component as a static web asset |
+| `UmbracoPrism.Client` | TypeScript/Lit web components — workflow editor, backoffice extensions, mobile shell |
+| `UmbracoPrism.MockBusinessApp` | Demo business API — hosts `IWorkflowRuntimeEngine`, loads workflow seed files, serves `/mockapp/` endpoints |
+| `UmbracoPrism.TestSite` | Demo Umbraco site wired to Prism Core and MockBusinessApp |
+| `UmbracoPrism.AppHost` | .NET Aspire orchestrator for local dev (Keycloak + TestSite + MockBusinessApp) |
+| `UmbracoPrism.KeycloakProxy` | YARP reverse proxy for Keycloak in Aspire |
+| `UmbracoPrism.ServiceDefaults` | Shared Aspire service defaults |
+| `UmbracoPrism.Core.Tests` | XUnit unit/integration test suite |
+
+---
+
+## Build and test commands
+
+### .NET
+
+```bash
+# Build everything
+dotnet build UmbracoPrism.sln
+
+# Run unit tests
+dotnet test src/UmbracoPrism.Core.Tests/
+
+# Run unit tests (Release, full filter)
+dotnet test UmbracoPrism.sln -c Release --filter FullyQualifiedName~UmbracoPrism.Core.Tests
+
+# Vulnerability scan
+dotnet list src/UmbracoPrism.Core/UmbracoPrism.Core.csproj package --vulnerable --include-transitive
+```
+
+### TypeScript / Lit client
+
+```bash
+cd src/UmbracoPrism.Client
+
+# Build (TypeScript check + Vite bundle for both main and workflow editor)
+npm run build
+
+# Run Playwright tests (Storybook starts automatically via webServer config)
+node node_modules/.bin/playwright test --reporter=line
+
+# Run single Playwright test
+node node_modules/.bin/playwright test tests/prism-create-tenant-modal.spec.ts -g "test name"
+
+# Storybook dev server
+npm run storybook
+
+# Storybook tests (accessibility + interaction)
+npm run test-storybook:ci
+
+# Live stack E2E tests (requires Aspire running)
+npm run test:playwright:localhost-auth
+```
+
+### Aspire (full dev stack)
+
+```bash
+# Validate prerequisites first
+node scripts/validate-aspire-prereqs.mjs
+
+# Start via VS Code launch config: "C#: Aspire (Full Stack)"
+# Or: dotnet run --project src/UmbracoPrism.AppHost
+```
+
+---
+
+## Architecture essentials
+
+### Workflow model
+
+The canonical workflow contract is `WorkflowDefinitionFile` (C#) / `AuthoredWorkflow` (TypeScript). Key fields:
+
+- **`queues`** — named work queues (e.g. `web-user`, `admin`). Each stage belongs to one queue via `queueName`.
+- **`states`** — workflow stages, each owning their own `routes` array (replacing the old flat `transitions` array).
+- **`gateways`** — first-class Split/Join gateway nodes. State routes must target a gateway; gateway routes may target states or other gateways.
+- **`initialState`** — key of the starting state.
+- **`instancePolicy`** — `"single"` (one active instance per user) or `"multiple"`.
+
+State routes must always point to a gateway, never directly to another state. `ValidateGatewayRouting()` enforces this at save time.
+
+**Response states:** `"render"` (show this step), `"defer"` (wait), `"complete"`, `"error"`.
+
+Workflow saves are **memory-only** — POSTing to the editor writes to the in-memory store only; a restart reloads from seed files. This is intentional during the current demo/dev phase.
+
+### Queue model
+
+Host apps decide what queues exist and who can access them:
+- `TestSite` exposes `"web-user"` queue — applicant-facing stages.
+- `MockBusinessApp` exposes `"admin"` queue — reviewer/admin stages.
+
+The shared runtime does NOT enforce queue-level access control — that's the host's responsibility.
+
+### Workflow editor (TypeScript)
+
+Web components in `src/UmbracoPrism.Client/src/workflow-editor/`:
+- `prism-workflow-editor.ts` — main editor component
+- `prism-workflow-graph.ts` — canvas with lane bands, stage nodes, gateway nodes, route edges. Uses longest-path Kahn's algorithm for Y-rank; backward edges (Join loop-backs) are detected and removed from the ranking graph before layout.
+- `prism-workflow-editor-shell.ts` — standalone shell for embedding the editor
+- `types.ts` — canonical TypeScript types; includes compatibility getters for older `lane`/`transition` naming
+
+The graph layout uses `data-prism-lane` on stage button elements (stages are absolutely-positioned siblings of lane bands, not DOM children).
+
+### Seed files
+
+`src/UmbracoPrism.MockBusinessApp/workflow-seeds/` — four demo workflows:
+- `payment-demo.json` — two-queue, Split+Join gateways, payment flow
+- `planning.json` — single-queue, linear applicant flow
+- `planning-notification.json` — planning notification variant
+- `community-enquiry.json` — two-queue applicant/reviewer with approval loop
+- `information-request.json` — two-queue, SLA-driven review flow
+
+### Authentication
+
+OIDC via Keycloak. Stateless token handling; per-tenant JWKS validation; nonce hard-fail on mismatch. `IWorkflowRuntimeEngine` takes `WorkflowAccessProfile` (derived from the authenticated user's claims) for queue-aware routing.
+
+---
+
+## Key conventions
+
+### Testing
+
+- **Behavioural contracts**: tests assert what the user sees, not implementation details.
+- **Semantic selectors**: `getByRole`, `getByLabel`, `getByText`, `aria-*`, `data-prism-*` attributes. Never CSS classes or web component tag names.
+- **Date inputs**: target sub-fields by generated IDs — `{fieldKey}-day`, `{fieldKey}-month`, `{fieldKey}-year`.
+- **Error assertions**: always check both `[role="alert"]` error summary AND field-level errors.
+- C# tests: XUnit + Moq + FluentAssertions. No database mocks — integration tests use a real test host.
+- Playwright configs: `playwright.config.ts` (Storybook tests) and `playwright.localhost-auth.config.ts` (live Aspire stack tests, run separately).
+
+### Branch policy
+
+Feature branches + PRs for substantive changes. Branch naming: `{type}/{issue-number}-{kebab-slug}` or descriptive. Direct commits to `main` for trivial fixes only.
+
+### Commit conventions
+
+Always use [Conventional Commits](https://www.conventionalcommits.org/) format. The `/release` skill reads these to infer the semver bump automatically — so the signal must be accurate:
+
+| Prefix | Semver impact | Use for |
+|---|---|---|
+| `feat:` | **minor** | New user-facing capability |
+| `feat!:` or body contains `BREAKING CHANGE:` | **major** | Anything that breaks existing integrations or APIs |
+| `fix:` | patch | Bug fixes |
+| `perf:` | patch | Performance improvements |
+| `refactor:` | patch | Internal restructuring, no behaviour change |
+| `test:` | patch | Test additions/changes only |
+| `chore:` | patch | Tooling, build, deps — no user impact |
+| `docs:` | patch | Documentation only |
+
+When a commit introduces a breaking change, add a `BREAKING CHANGE: <description>` line in the commit body explaining what breaks and how to migrate. This is what the release skill reads to trigger a major bump.
+
+### Code style
+
+- No speculative abstractions — solve the problem at hand.
+- No comments unless the *why* is genuinely non-obvious.
+- C#: idiomatic .NET 10 / Umbraco v17 patterns. Use `IContentTypeService`, `IDataTypeService` etc. from DI — don't re-register.
+- TypeScript: Lit web components. Use `data-prism-*` attributes to expose semantic hooks for Playwright.
+
+---
+
+## Demo credentials (local)
+
+| What | Username | Password |
+|---|---|---|
+| TestSite (Keycloak SSO) | `demo@prism.local` | `password` |
+| Umbraco backoffice | `admin@prism.local` | `PrismLocal!12345` |
+| Keycloak admin | `admin` | `admin` |

--- a/UmbracoPrism.sln
+++ b/UmbracoPrism.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UmbracoPrism.WorkflowEditor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UmbracoPrism.WorkflowRuntime", "src\UmbracoPrism.WorkflowRuntime\UmbracoPrism.WorkflowRuntime.csproj", "{129A5F87-526B-41B7-A144-16FC17A35CEE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UmbracoPrism.uSync", "src\UmbracoPrism.uSync\UmbracoPrism.uSync.csproj", "{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -155,6 +157,18 @@ Global
 		{129A5F87-526B-41B7-A144-16FC17A35CEE}.Release|x64.Build.0 = Release|Any CPU
 		{129A5F87-526B-41B7-A144-16FC17A35CEE}.Release|x86.ActiveCfg = Release|Any CPU
 		{129A5F87-526B-41B7-A144-16FC17A35CEE}.Release|x86.Build.0 = Release|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Debug|x64.Build.0 = Debug|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Debug|x86.Build.0 = Debug|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Release|x64.ActiveCfg = Release|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Release|x64.Build.0 = Release|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Release|x86.ActiveCfg = Release|Any CPU
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -170,5 +184,6 @@ Global
 		{6C8D7E44-BB7B-462D-AEA6-E0F0E9F838E9} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{D927198A-179C-4F2A-ACC0-4746D3DCE043} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{129A5F87-526B-41B7-A144-16FC17A35CEE} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{72A8536D-1AEC-488F-97F8-4EC3DC4A2A8D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/UmbracoPrism.Client/src/backoffice/prism-create-tenant-modal.ts
+++ b/src/UmbracoPrism.Client/src/backoffice/prism-create-tenant-modal.ts
@@ -46,6 +46,15 @@ export class PrismCreateTenantModalElement extends UmbElementMixin(LitElement) {
 
   @state() private _activeTab = 'general';
   @state() private _maximized = false;
+  @state() private _tokenStatus: Array<{
+    fieldName: string;
+    rawValue: string;
+    tokenName: string;
+    resolvedValue: string | null;
+    isResolved: boolean;
+  }> = [];
+  @state() private _tokenStatusLoading = false;
+  @state() private _tokenStatusError: string | null = null;
   @state() private _brandingTabs: Array<{
     label: string;
     variables: Array<{
@@ -424,7 +433,7 @@ export class PrismCreateTenantModalElement extends UmbElementMixin(LitElement) {
 
   private _ensureActiveTab() {
     const brandingTabKeys = this._brandingTabs.map((_, index) => this._brandingTabKey(index));
-    const allowedTabs = new Set(['general', 'identity', 'mobile', ...brandingTabKeys]);
+    const allowedTabs = new Set(['general', 'identity', 'mobile', 'tokens', ...brandingTabKeys]);
 
     if (!allowedTabs.has(this._activeTab)) {
       this._activeTab = 'general';
@@ -491,6 +500,139 @@ export class PrismCreateTenantModalElement extends UmbElementMixin(LitElement) {
     }
   }
 
+  private async _fetchTokenStatus() {
+    if (!this._id) return;
+
+    this._tokenStatusLoading = true;
+    this._tokenStatusError = null;
+
+    try {
+      let token: string | undefined;
+      await Promise.race([
+        new Promise<void>(resolve => {
+          this.consumeContext(UMB_AUTH_CONTEXT, async (authContext) => {
+            if (authContext) token = await authContext.getLatestToken();
+            resolve();
+          });
+        }),
+        new Promise<void>(resolve => setTimeout(resolve, 500))
+      ]);
+
+      const response = await fetch(
+        `/umbraco/management/api/v1/prism/tenants/${this._id}/token-status`,
+        { headers: token ? { 'Authorization': `Bearer ${token}` } : {} }
+      );
+
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+      this._tokenStatus = await response.json();
+    } catch (err) {
+      this._tokenStatusError = err instanceof Error ? err.message : 'Unknown error';
+    } finally {
+      this._tokenStatusLoading = false;
+    }
+  }
+
+  private _renderTokensTab() {
+    const isEditMode = this._id !== null;
+    const missingTokens = this._tokenStatus.filter(t => !t.isResolved);
+
+    const missingSnippet = missingTokens.length > 0
+      ? '{\n' + missingTokens.map(t => `  "${t.tokenName}": "your-value-here"`).join(',\n') + '\n}'
+      : null;
+
+    return html`
+      <div role="tabpanel" id="tokens-panel" aria-labelledby="tokens-tab" class="tab-content">
+        <uui-box>
+          <h3 style="margin-top:0">Environment Tokens</h3>
+          <p class="description">
+            Any field value in this tenant can hold a <code>{{TOKEN_NAME}}</code> placeholder instead of
+            a literal string. Prism replaces these at runtime from your application configuration.
+            Token names must be <strong>UPPERCASE with underscores</strong>.
+          </p>
+          <p class="description">
+            Tokens resolve from the <strong>root level</strong> of <code>appsettings.json</code> — not
+            nested under any section. For example, to use <code>{{OIDC_AUTHORITY}}</code> in the
+            OIDC Authority field, add this to your <code>appsettings.json</code>:
+          </p>
+          <pre class="token-snippet">{
+  "OIDC_AUTHORITY": "https://auth.example.com/realms/prod"
+}</pre>
+          <p class="description">
+            You can also set tokens as environment variables (<code>OIDC_AUTHORITY=https://…</code>),
+            or via any other .NET configuration source. The Hostname field is resolved at uSync
+            import time rather than runtime.
+          </p>
+
+          ${!isEditMode ? html`
+            <div class="info-banner" role="note">
+              Save this tenant first to inspect its token status.
+            </div>
+          ` : this._tokenStatusLoading ? html`
+            <p class="description">Loading token status…</p>
+          ` : this._tokenStatusError ? html`
+            <small class="error-text" role="alert">Could not load token status: ${this._tokenStatusError}</small>
+          ` : this._tokenStatus.length === 0 ? html`
+            <div class="info-banner" role="note">
+              No <code>{{TOKEN_NAME}}</code> placeholders are currently used in this tenant's identity fields.
+              You can add them by typing <code>{{MY_TOKEN}}</code> directly into any field on the Identity tab and saving.
+            </div>
+          ` : html`
+            <table class="token-table" aria-label="Token resolution status">
+              <thead>
+                <tr>
+                  <th scope="col">Token</th>
+                  <th scope="col">Field</th>
+                  <th scope="col">Resolved value</th>
+                  <th scope="col">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${this._tokenStatus.map(t => html`
+                  <tr>
+                    <td><code>{{${t.tokenName}}}</code></td>
+                    <td>${t.fieldName}</td>
+                    <td>
+                      ${t.isResolved
+                        ? html`<code class="resolved-value">${t.resolvedValue}</code>`
+                        : html`<span class="token-missing">—</span>`}
+                    </td>
+                    <td>
+                      ${t.isResolved
+                        ? html`<span class="token-badge token-badge--ok" aria-label="Resolved">✓ Resolved</span>`
+                        : html`<span class="token-badge token-badge--missing" aria-label="Missing">⚠ Missing</span>`}
+                    </td>
+                  </tr>
+                `)}
+              </tbody>
+            </table>
+
+            ${missingSnippet ? html`
+              <div class="missing-tokens-hint">
+                <strong>Add these to your <code>appsettings.json</code> (root level):</strong>
+                <pre class="token-snippet">${missingSnippet}</pre>
+                <p style="margin:0.25rem 0 0">
+                  Or as environment variables, one per line:
+                  <code>${missingTokens.map(t => t.tokenName + '=your-value').join(' · ')}</code>
+                </p>
+              </div>
+            ` : ''}
+
+            <p style="margin-top:0.75rem">
+              <uui-button
+                look="secondary"
+                compact
+                label="Refresh token status"
+                @click=${() => this._fetchTokenStatus()}>
+                Refresh
+              </uui-button>
+            </p>
+          `}
+        </uui-box>
+      </div>
+    `;
+  }
+
   private _handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'Escape' && this._maximized) {
       event.stopPropagation();
@@ -511,10 +653,12 @@ export class PrismCreateTenantModalElement extends UmbElementMixin(LitElement) {
     const nextTab = tab.dataset.tabKey;
     if (nextTab && nextTab !== this._activeTab) {
       this._activeTab = nextTab;
-      
-      // Fetch branding metadata when switching to a branding tab
+
       if (nextTab.startsWith('branding-')) {
         this._fetchBrandingMetadata();
+      }
+      if (nextTab === 'tokens') {
+        this._fetchTokenStatus();
       }
     }
   }
@@ -1733,6 +1877,13 @@ export class PrismCreateTenantModalElement extends UmbElementMixin(LitElement) {
           ?active=${this._activeTab === 'mobile'}>
           Produce Mobile
         </uui-tab>
+        <uui-tab
+          label="Environment Tokens"
+          id="tokens-tab"
+          data-tab-key="tokens"
+          ?active=${this._activeTab === 'tokens'}>
+          Environment Tokens
+        </uui-tab>
         ${brandingTabs.map(({ tab, key }, index) => html`
           <uui-tab
             label=${tab.label}
@@ -1751,9 +1902,11 @@ export class PrismCreateTenantModalElement extends UmbElementMixin(LitElement) {
             ? this._renderIdentityTab()
             : this._activeTab === 'mobile'
               ? this._renderMobileTab()
-            : brandingTabs.map(({ key }, index) =>
-                this._activeTab === key ? this._renderBrandingTab(index) : ''
-              )}
+              : this._activeTab === 'tokens'
+                ? this._renderTokensTab()
+                : brandingTabs.map(({ key }, index) =>
+                    this._activeTab === key ? this._renderBrandingTab(index) : ''
+                  )}
       </div>
       </uui-dialog-layout>
     `;
@@ -1942,6 +2095,79 @@ export class PrismCreateTenantModalElement extends UmbElementMixin(LitElement) {
     }
     .error-text {
       color: var(--uui-color-danger-standalone);
+    }
+    .info-banner {
+      background: var(--uui-color-surface-alt);
+      border: 1px solid var(--uui-color-border);
+      border-radius: var(--uui-border-radius);
+      padding: var(--uui-size-space-3) var(--uui-size-space-4);
+      font-size: 0.85rem;
+      color: var(--uui-color-text-alt);
+    }
+    .token-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.85rem;
+      margin-top: var(--uui-size-space-3);
+    }
+    .token-table th {
+      text-align: left;
+      padding: 0.35rem 0.6rem;
+      background: var(--uui-color-surface-alt);
+      border-bottom: 2px solid var(--uui-color-border);
+      font-weight: 600;
+    }
+    .token-table td {
+      padding: 0.35rem 0.6rem;
+      border-bottom: 1px solid var(--uui-color-border-standalone);
+      vertical-align: middle;
+    }
+    .token-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.78rem;
+      font-weight: 600;
+    }
+    .token-badge--ok {
+      background: color-mix(in srgb, var(--uui-color-positive) 15%, transparent);
+      color: var(--uui-color-positive-standalone);
+    }
+    .token-badge--missing {
+      background: color-mix(in srgb, var(--uui-color-warning) 15%, transparent);
+      color: var(--uui-color-warning-standalone);
+    }
+    .resolved-value {
+      max-width: 220px;
+      display: inline-block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      vertical-align: bottom;
+    }
+    .token-missing {
+      color: var(--uui-color-text-alt);
+    }
+    .token-snippet {
+      background: var(--uui-color-surface-alt);
+      border: 1px solid var(--uui-color-border);
+      border-radius: var(--uui-border-radius);
+      padding: var(--uui-size-space-3) var(--uui-size-space-4);
+      font-family: monospace;
+      font-size: 0.82rem;
+      white-space: pre;
+      overflow-x: auto;
+      margin: 0.4rem 0 0.75rem;
+    }
+    .missing-tokens-hint {
+      margin-top: var(--uui-size-space-4);
+      padding: var(--uui-size-space-3) var(--uui-size-space-4);
+      background: color-mix(in srgb, var(--uui-color-warning) 8%, transparent);
+      border: 1px solid color-mix(in srgb, var(--uui-color-warning) 40%, transparent);
+      border-radius: var(--uui-border-radius);
+      font-size: 0.85rem;
     }
     .section-title {
       margin: var(--uui-size-space-5) 0 var(--uui-size-space-2);

--- a/src/UmbracoPrism.Client/tests/support/live-app-host.ts
+++ b/src/UmbracoPrism.Client/tests/support/live-app-host.ts
@@ -10,6 +10,12 @@ const readinessTimeoutMs = 480_000; // 8 minutes — CI runners vary; 5min was t
 const readinessPollIntervalMs = 10_000;
 const readinessCheckpointIntervalMs = 30_000;
 const probeTimeoutMs = 5_000;
+// A wedged resource (port still listening, process not actually responding) doesn't recover on
+// its own — waiting out the full readinessTimeoutMs just burns the CI budget. If the exact same
+// set of checks has been pending this long with zero progress, restart the whole stack once
+// instead of waiting it out.
+const stallRecoveryThresholdMs = 180_000; // 3 minutes
+const maxRecoveryAttempts = 1;
 
 // Known patterns in Umbraco's default "unseeded" splash page — when we see these,
 // classify as "still seeding" (not a hard failure). CI hardware timing can push
@@ -122,6 +128,16 @@ type ReadinessStatus = {
   failures: string[];
 };
 
+class StallDetectedError extends Error {
+  constructor(
+    readonly reason: string,
+    readonly statuses: ReadinessStatus[]
+  ) {
+    super(`Readiness stalled: ${reason}`);
+    this.name = 'StallDetectedError';
+  }
+}
+
 export class LiveAppHost {
   private child: ChildProcessWithoutNullStreams | undefined;
   private resetTestSiteRuntimeOnNextStart = true;
@@ -132,6 +148,10 @@ export class LiveAppHost {
       return;
     }
 
+    await this.attemptStart(0);
+  }
+
+  private async attemptStart(recoveryAttempt: number): Promise<void> {
     await this.ensurePortsAreAvailable();
 
     this.child = spawn('dotnet', ['run', '--project', appHostProject], {
@@ -154,6 +174,22 @@ export class LiveAppHost {
       this.resetTestSiteRuntimeOnNextStart = false;
     } catch (error) {
       await this.stop().catch(() => undefined);
+
+      if (error instanceof StallDetectedError && recoveryAttempt < maxRecoveryAttempts) {
+        console.log(
+          `[readiness] stack appears wedged (${error.reason}); restarting once and retrying ` +
+            `(recovery attempt ${recoveryAttempt + 1}/${maxRecoveryAttempts}).`
+        );
+        await this.attemptStart(recoveryAttempt + 1);
+        return;
+      }
+
+      if (error instanceof StallDetectedError) {
+        throw new Error(
+          this.buildTimeoutDiagnostics(`Stack stalled: ${error.reason}`, error.statuses)
+        );
+      }
+
       throw error;
     }
   }
@@ -272,6 +308,8 @@ export class LiveAppHost {
     const firstReadyAt = new Map<string, number>();
     const lastObservedFailure = new Map<string, string>();
     let lastCheckpointAt = -readinessCheckpointIntervalMs;
+    let stalledPendingNames = '';
+    let stalledSinceMs = 0;
 
     while (Date.now() - start < readinessTimeoutMs) {
       if (this.child && this.child.exitCode !== null) {
@@ -289,16 +327,41 @@ export class LiveAppHost {
         return;
       }
 
+      const pendingNames = latestStatuses
+        .filter(status => !status.ok)
+        .map(status => status.check.name)
+        .sort()
+        .join(',');
+
+      if (pendingNames !== stalledPendingNames) {
+        stalledPendingNames = pendingNames;
+        stalledSinceMs = elapsedMs;
+      } else if (elapsedMs - stalledSinceMs >= stallRecoveryThresholdMs) {
+        throw new StallDetectedError(
+          `no progress on [${pendingNames}] for ${formatDuration(elapsedMs - stalledSinceMs)}`,
+          latestStatuses
+        );
+      }
+
       await delay(readinessPollIntervalMs);
     }
 
     throw new Error(
-      `Timed out waiting ${formatDuration(readinessTimeoutMs)} for the Aspire localhost stack to become ready.\n\n` +
-        `Readiness diagnostics:\n${formatReadinessDiagnostics(latestStatuses)}\n\n` +
-        `Port diagnostics:\n${formatPortDiagnostics()}\n\n` +
-        `Keycloak container logs:\n${captureDockerContainerLogs('keycloak')}\n\n` +
-        `Relevant resource logs:\n${this.formatResourceLogs()}\n\n` +
-        `Recent logs:\n${this.formatLogs()}`
+      this.buildTimeoutDiagnostics(
+        `Timed out waiting ${formatDuration(readinessTimeoutMs)} for the Aspire localhost stack to become ready.`,
+        latestStatuses
+      )
+    );
+  }
+
+  private buildTimeoutDiagnostics(headline: string, statuses: ReadinessStatus[]): string {
+    return (
+      `${headline}\n\n` +
+      `Readiness diagnostics:\n${formatReadinessDiagnostics(statuses)}\n\n` +
+      `Port diagnostics:\n${formatPortDiagnostics()}\n\n` +
+      `Keycloak container logs:\n${captureDockerContainerLogs('keycloak')}\n\n` +
+      `Relevant resource logs:\n${this.formatResourceLogs()}\n\n` +
+      `Recent logs:\n${this.formatLogs()}`
     );
   }
 

--- a/src/UmbracoPrism.Core.Tests/TenantManagementControllerTests.cs
+++ b/src/UmbracoPrism.Core.Tests/TenantManagementControllerTests.cs
@@ -258,7 +258,8 @@ public class TenantManagementControllerTests
             tenantService.Object,
             Mock.Of<IBrandingService>(),
             Mock.Of<IMobileBundleService>(),
-            Mock.Of<IPrismBrandingMetadataService>());
+            Mock.Of<IPrismBrandingMetadataService>(),
+            Mock.Of<ITenantTokenResolver>());
 
         return (controller, db, tenantService, dbFactory);
     }

--- a/src/UmbracoPrism.Core.Tests/TenantServiceCacheStrategyTests.cs
+++ b/src/UmbracoPrism.Core.Tests/TenantServiceCacheStrategyTests.cs
@@ -319,6 +319,6 @@ public class TenantServiceCacheStrategyTests
         var isolatedCaches = new IsolatedCaches(_ => new ObjectCacheAppCache());
         var appCaches = new AppCaches(runtimeCache, requestCache.Object, isolatedCaches);
 
-        return new TenantService(databaseFactory, appCaches, NullLogger<TenantService>.Instance);
+        return new TenantService(databaseFactory, appCaches, Mock.Of<ITenantTokenResolver>(), NullLogger<TenantService>.Instance);
     }
 }

--- a/src/UmbracoPrism.Core/Controllers/TenantManagementController.cs
+++ b/src/UmbracoPrism.Core/Controllers/TenantManagementController.cs
@@ -26,7 +26,8 @@ public class TenantManagementController(
     ITenantService tenantService,
     IBrandingService brandingService,
     IMobileBundleService mobileBundleService,
-    IPrismBrandingMetadataService brandingMetadataService) : ManagementApiControllerBase
+    IPrismBrandingMetadataService brandingMetadataService,
+    ITenantTokenResolver tokenResolver) : ManagementApiControllerBase
 {
     /// <summary>
     /// Gets all registered tenants.
@@ -232,6 +233,29 @@ public class TenantManagementController(
         tenantService.InvalidateDomain(tenant.Hostname, "tenant-delete");
 
         return Ok();
+    }
+
+    /// <summary>
+    /// Returns the token resolution status for a tenant's identity fields.
+    /// Used by the "Environment Tokens" backoffice tab to show editors what
+    /// {{TOKEN_NAME}} placeholders exist and whether they are configured.
+    /// </summary>
+    [HttpGet("tenants/{id:int}/token-status")]
+    public IActionResult GetTenantTokenStatus(int id)
+    {
+        using var db = databaseFactory.CreateDatabase();
+        var tenant = db.SingleOrDefaultById<PrismTenantSchema>(id);
+        if (tenant is null) return NotFound();
+
+        var tokens = tokenResolver.ExtractTokenStatus(tenant);
+        return Ok(tokens.Select(t => new
+        {
+            fieldName = t.FieldName,
+            rawValue = t.RawValue,
+            tokenName = t.TokenName,
+            resolvedValue = t.ResolvedValue,
+            isResolved = t.IsResolved
+        }));
     }
 
     /// <summary>

--- a/src/UmbracoPrism.Core/PrismComposer.cs
+++ b/src/UmbracoPrism.Core/PrismComposer.cs
@@ -25,6 +25,7 @@ public class PrismComposer : IComposer
         // 1. Core Services
         builder.Services.AddHttpContextAccessor();
         builder.Services.AddSingleton<ISecretVaultService, SecretVaultService>();
+        builder.Services.AddSingleton<ITenantTokenResolver, TenantTokenResolver>();
         builder.Services.AddSingleton<ITenantService, TenantService>();
         builder.Services.AddSingleton<IBrandingService, BrandingService>();
         builder.Services.AddSingleton<IMobileBundleService, MobileBundleService>();

--- a/src/UmbracoPrism.Core/Services/ITenantTokenResolver.cs
+++ b/src/UmbracoPrism.Core/Services/ITenantTokenResolver.cs
@@ -1,0 +1,38 @@
+using UmbracoPrism.Core.Persistence;
+
+namespace UmbracoPrism.Core.Services;
+
+/// <summary>
+/// Resolves {{TOKEN_NAME}} placeholders in tenant field values using IConfiguration
+/// (appsettings.json, environment variables, Key Vault, etc.).
+/// </summary>
+public interface ITenantTokenResolver
+{
+    /// <summary>
+    /// Replaces every {{TOKEN_NAME}} occurrence in <paramref name="value"/> with the
+    /// corresponding value from IConfiguration, leaving unmatched tokens intact.
+    /// Returns the original string unchanged when no tokens are present.
+    /// </summary>
+    string Resolve(string? value);
+
+    /// <summary>
+    /// Scans all tokenizable fields on <paramref name="tenant"/> and returns one result
+    /// per distinct token found, showing both the raw placeholder and its resolved value.
+    /// </summary>
+    IReadOnlyList<TenantTokenResult> ExtractTokenStatus(PrismTenantSchema tenant);
+}
+
+/// <summary>
+/// Describes a single {{TOKEN_NAME}} found in a tenant field and its resolution outcome.
+/// </summary>
+/// <param name="FieldName">The property name on the tenant schema (e.g. "OidcAuthority").</param>
+/// <param name="RawValue">The full field value as stored, including the token placeholder.</param>
+/// <param name="TokenName">The bare token name, without the {{ }} delimiters.</param>
+/// <param name="ResolvedValue">The value from IConfiguration, or <see langword="null"/> when unresolved.</param>
+/// <param name="IsResolved">True when a configuration value was found for this token.</param>
+public record TenantTokenResult(
+    string FieldName,
+    string RawValue,
+    string TokenName,
+    string? ResolvedValue,
+    bool IsResolved);

--- a/src/UmbracoPrism.Core/Services/TenantService.cs
+++ b/src/UmbracoPrism.Core/Services/TenantService.cs
@@ -17,6 +17,7 @@ public class TenantService : ITenantService
 
     private readonly IUmbracoDatabaseFactory _databaseFactory;
     private readonly IAppPolicyCache _runtimeCache;
+    private readonly ITenantTokenResolver _tokenResolver;
     private readonly ILogger<TenantService> _logger;
 
     private long _cacheHits;
@@ -29,11 +30,17 @@ public class TenantService : ITenantService
     /// </summary>
     /// <param name="databaseFactory">Factory used to open Umbraco database connections.</param>
     /// <param name="appCaches">Application cache container used for runtime tenant caching.</param>
+    /// <param name="tokenResolver">Resolves {{TOKEN_NAME}} placeholders in tenant fields at runtime.</param>
     /// <param name="logger">Logger used for cache invalidation diagnostics.</param>
-    public TenantService(IUmbracoDatabaseFactory databaseFactory, AppCaches appCaches, ILogger<TenantService> logger)
+    public TenantService(
+        IUmbracoDatabaseFactory databaseFactory,
+        AppCaches appCaches,
+        ITenantTokenResolver tokenResolver,
+        ILogger<TenantService> logger)
     {
         _databaseFactory = databaseFactory;
         _runtimeCache = appCaches.RuntimeCache;
+        _tokenResolver = tokenResolver;
         _logger = logger;
     }
 
@@ -82,26 +89,28 @@ public class TenantService : ITenantService
             var brandingOverrides = ParseBrandingOverrides(tenantSchema.BrandingOverrides);
             var mobileBrandingOverrides = ParseBrandingOverrides(tenantSchema.MobileBrandingOverrides);
 
+            // Resolve {{TOKEN_NAME}} placeholders in identity fields. Hostname is the lookup
+            // key and is never stored with tokens — see PrismTenantSyncHandler for details.
             return new PrismTenant
             {
                 Id = tenantSchema.Id,
                 Name = tenantSchema.Name,
                 Hostname = tenantSchema.Hostname,
-                EntraTenantId = tenantSchema.EntraTenantId,
-                EntraClientId = tenantSchema.EntraClientId,
-                SecretKeyName = tenantSchema.SecretKeyName,
+                EntraTenantId = _tokenResolver.Resolve(tenantSchema.EntraTenantId),
+                EntraClientId = _tokenResolver.Resolve(tenantSchema.EntraClientId),
+                SecretKeyName = _tokenResolver.Resolve(tenantSchema.SecretKeyName),
                 BrandingOverrides = brandingOverrides,
                 MobileBrandingOverrides = mobileBrandingOverrides,
                 BrandingCssDeclarations = BuildCssDeclarations(brandingOverrides),
                 MobileBrandingCssDeclarations = BuildCssDeclarations(mobileBrandingOverrides),
                 AllowBiometricLogin = tenantSchema.AllowBiometricLogin,
-                OidcAuthority = tenantSchema.OidcAuthority,
-                OidcClientId = tenantSchema.OidcClientId,
-                OidcClientSecretProvider = tenantSchema.OidcClientSecretProvider
+                OidcAuthority = _tokenResolver.Resolve(tenantSchema.OidcAuthority),
+                OidcClientId = _tokenResolver.Resolve(tenantSchema.OidcClientId),
+                OidcClientSecretProvider = _tokenResolver.Resolve(tenantSchema.OidcClientSecretProvider)
                     ?? (!string.IsNullOrWhiteSpace(tenantSchema.OidcClientSecret)
                         ? PrismSecretProviderNames.Inline
                         : null),
-                OidcClientSecretReference = tenantSchema.OidcClientSecretReference ?? tenantSchema.OidcClientSecret
+                OidcClientSecretReference = _tokenResolver.Resolve(tenantSchema.OidcClientSecretReference ?? tenantSchema.OidcClientSecret)
             };
         }, TimeSpan.FromMinutes(30));
 

--- a/src/UmbracoPrism.Core/Services/TenantTokenResolver.cs
+++ b/src/UmbracoPrism.Core/Services/TenantTokenResolver.cs
@@ -1,0 +1,65 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+using UmbracoPrism.Core.Persistence;
+
+namespace UmbracoPrism.Core.Services;
+
+/// <summary>
+/// Resolves {{TOKEN_NAME}} placeholders in tenant field values using IConfiguration.
+/// Tokens must be ALL_CAPS_WITH_UNDERSCORES; unresolved tokens are left as-is.
+/// </summary>
+public sealed class TenantTokenResolver : ITenantTokenResolver
+{
+    // Matches {{TOKEN_NAME}} where the name is uppercase letters, digits, and underscores.
+    private static readonly Regex TokenPattern =
+        new(@"\{\{([A-Z][A-Z0-9_]*)\}\}", RegexOptions.Compiled);
+
+    private readonly IConfiguration _configuration;
+
+    public TenantTokenResolver(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public string Resolve(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return value ?? string.Empty;
+
+        return TokenPattern.Replace(value, match =>
+            _configuration[match.Groups[1].Value] ?? match.Value);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<TenantTokenResult> ExtractTokenStatus(PrismTenantSchema tenant)
+    {
+        // Hostname is intentionally excluded — it is the DB lookup key and must be
+        // stored as a resolved value (tokens are resolved at uSync import time, not runtime).
+        (string Field, string? Value)[] fields =
+        [
+            ("EntraTenantId",           tenant.EntraTenantId),
+            ("EntraClientId",           tenant.EntraClientId),
+            ("SecretKeyName",           tenant.SecretKeyName),
+            ("OidcAuthority",           tenant.OidcAuthority),
+            ("OidcClientId",            tenant.OidcClientId),
+            ("OidcClientSecretProvider",tenant.OidcClientSecretProvider),
+            ("OidcClientSecretReference",tenant.OidcClientSecretReference),
+        ];
+
+        var results = new List<TenantTokenResult>();
+
+        foreach (var (field, value) in fields)
+        {
+            if (string.IsNullOrWhiteSpace(value)) continue;
+
+            foreach (Match match in TokenPattern.Matches(value))
+            {
+                var tokenName = match.Groups[1].Value;
+                var configValue = _configuration[tokenName];
+                results.Add(new TenantTokenResult(field, value, tokenName, configValue, configValue is not null));
+            }
+        }
+
+        return results;
+    }
+}

--- a/src/UmbracoPrism.TestSite/UmbracoPrism.TestSite.csproj
+++ b/src/UmbracoPrism.TestSite/UmbracoPrism.TestSite.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\UmbracoPrism.Core\UmbracoPrism.Core.csproj" />
+    <ProjectReference Include="..\UmbracoPrism.uSync\UmbracoPrism.uSync.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.uSync/PrismUSyncComposer.cs
+++ b/src/UmbracoPrism.uSync/PrismUSyncComposer.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using UmbracoPrism.Core;
+using uSync.BackOffice;
+
+namespace UmbracoPrism.uSync;
+
+[ComposeAfter(typeof(PrismComposer))]
+public class PrismUSyncComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.AdduSync();
+    }
+}

--- a/src/UmbracoPrism.uSync/Serialization/PrismTenantSerializer.cs
+++ b/src/UmbracoPrism.uSync/Serialization/PrismTenantSerializer.cs
@@ -1,0 +1,184 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Infrastructure.Persistence;
+using uSync.Core;
+using uSync.Core.Models;
+using uSync.Core.Serialization;
+using UmbracoPrism.Core.Persistence;
+using UmbracoPrism.Core.Services;
+
+namespace UmbracoPrism.uSync.Serialization;
+
+[SyncSerializer("3f7b9c21-4e8d-4a1c-b6d2-5e0f1a2b3c4d", "Prism Tenant Serializer", "PrismTenant")]
+public class PrismTenantSerializer : SyncSerializerRoot<PrismTenantSchema>, ISyncSerializer<PrismTenantSchema>
+{
+    private readonly IUmbracoDatabaseFactory _databaseFactory;
+    private readonly ITenantTokenResolver _tokenResolver;
+    private readonly ITenantService _tenantService;
+
+    public PrismTenantSerializer(
+        ILogger<SyncSerializerRoot<PrismTenantSchema>> logger,
+        IUmbracoDatabaseFactory databaseFactory,
+        ITenantTokenResolver tokenResolver,
+        ITenantService tenantService) : base(logger)
+    {
+        _databaseFactory = databaseFactory;
+        _tokenResolver = tokenResolver;
+        _tenantService = tenantService;
+    }
+
+    public override Guid ItemKey(PrismTenantSchema item) => DeterministicGuid(Slugify(item.Name));
+    public override string ItemAlias(PrismTenantSchema item) => Slugify(item.Name);
+
+    public override Task<PrismTenantSchema?> FindItemAsync(Guid key)
+    {
+        using var db = _databaseFactory.CreateDatabase();
+        var result = db.Fetch<PrismTenantSchema>()
+            .FirstOrDefault(t => DeterministicGuid(Slugify(t.Name)) == key);
+        return Task.FromResult(result);
+    }
+
+    public override Task<PrismTenantSchema?> FindItemAsync(string alias)
+    {
+        using var db = _databaseFactory.CreateDatabase();
+        var result = db.Fetch<PrismTenantSchema>()
+            .FirstOrDefault(t => Slugify(t.Name) == alias);
+        return Task.FromResult(result);
+    }
+
+    public override Task SaveItemAsync(PrismTenantSchema item)
+    {
+        using var db = _databaseFactory.CreateDatabase();
+        if (item.Id > 0)
+            db.Update(item);
+        else
+            db.Insert(item);
+        _tenantService.InvalidateDomain(item.Hostname, "usync-import");
+        return Task.CompletedTask;
+    }
+
+    public override Task DeleteItemAsync(PrismTenantSchema item)
+    {
+        using var db = _databaseFactory.CreateDatabase();
+        db.Delete(item);
+        _tenantService.InvalidateDomain(item.Hostname, "usync-delete");
+        return Task.CompletedTask;
+    }
+
+    protected override Task<SyncAttempt<XElement>> SerializeCoreAsync(PrismTenantSchema item, SyncSerializerOptions options)
+    {
+        if (item is null)
+            return Task.FromResult(SyncAttempt<XElement>.Fail(string.Empty, null, ChangeType.Fail, "Item is null", null));
+
+        var alias = ItemAlias(item);
+        var branding = ParseOverrides(item.BrandingOverrides);
+        var mobileBranding = ParseOverrides(item.MobileBrandingOverrides);
+
+        var node = InitializeBaseNode(item, alias, 1);
+        node.Add(
+            new XElement("Info",
+                new XElement("Name", item.Name),
+                new XElement("Hostname", item.Hostname),
+                new XElement("AllowBiometricLogin", item.AllowBiometricLogin)),
+            new XElement("Identity",
+                NullableElement("EntraTenantId", item.EntraTenantId),
+                NullableElement("EntraClientId", item.EntraClientId),
+                NullableElement("SecretKeyName", item.SecretKeyName),
+                NullableElement("OidcAuthority", item.OidcAuthority),
+                NullableElement("OidcClientId", item.OidcClientId),
+                NullableElement("OidcClientSecretProvider", item.OidcClientSecretProvider),
+                NullableElement("OidcClientSecretReference", item.OidcClientSecretReference)),
+            new XElement("Branding",
+                branding.Select(kv => new XElement("Override", new XAttribute("Variable", kv.Key), kv.Value))),
+            new XElement("MobileBranding",
+                mobileBranding.Select(kv => new XElement("Override", new XAttribute("Variable", kv.Key), kv.Value))));
+
+        return Task.FromResult(SyncAttempt<XElement>.Succeed(alias, node, ChangeType.Export, new List<uSyncChange>()));
+    }
+
+    protected override async Task<SyncAttempt<PrismTenantSchema>> DeserializeCoreAsync(XElement node, SyncSerializerOptions options)
+    {
+        var existing = await FindItemAsync(node);
+        var schema = existing ?? new PrismTenantSchema();
+
+        var info = node.Element("Info");
+        var identity = node.Element("Identity");
+
+        var rawHostname = info?.Element("Hostname")?.Value ?? string.Empty;
+        schema.Hostname = (_tokenResolver.Resolve(rawHostname) ?? rawHostname).Trim().ToLowerInvariant();
+
+        if (string.IsNullOrWhiteSpace(schema.Hostname))
+            return SyncAttempt<PrismTenantSchema>.Fail(node.GetAlias(), default, ChangeType.Fail,
+                "Hostname resolved to empty — check token configuration", null);
+
+        schema.Name = info?.Element("Name")?.Value ?? string.Empty;
+        schema.AllowBiometricLogin = ParseBool(info?.Element("AllowBiometricLogin")?.Value, defaultValue: true);
+        schema.EntraTenantId = NullIfEmpty(identity?.Element("EntraTenantId")?.Value);
+        schema.EntraClientId = NullIfEmpty(identity?.Element("EntraClientId")?.Value);
+        schema.SecretKeyName = NullIfEmpty(identity?.Element("SecretKeyName")?.Value);
+        schema.OidcAuthority = NullIfEmpty(identity?.Element("OidcAuthority")?.Value);
+        schema.OidcClientId = NullIfEmpty(identity?.Element("OidcClientId")?.Value);
+        schema.OidcClientSecretProvider = NullIfEmpty(identity?.Element("OidcClientSecretProvider")?.Value);
+        schema.OidcClientSecretReference = NullIfEmpty(identity?.Element("OidcClientSecretReference")?.Value);
+
+        var branding = node.Element("Branding")?
+            .Elements("Override")
+            .Where(e => e.Attribute("Variable") is not null)
+            .ToDictionary(e => e.Attribute("Variable")!.Value, e => e.Value)
+            ?? new Dictionary<string, string>();
+
+        var mobileBranding = node.Element("MobileBranding")?
+            .Elements("Override")
+            .Where(e => e.Attribute("Variable") is not null)
+            .ToDictionary(e => e.Attribute("Variable")!.Value, e => e.Value)
+            ?? new Dictionary<string, string>();
+
+        schema.BrandingOverrides = branding.Count > 0 ? JsonSerializer.Serialize(branding) : null;
+        schema.MobileBrandingOverrides = mobileBranding.Count > 0 ? JsonSerializer.Serialize(mobileBranding) : null;
+
+        // Preserve legacy inline secret — never exported, must survive a round-trip.
+        if (existing is not null)
+            schema.OidcClientSecret = existing.OidcClientSecret;
+
+        return SyncAttempt<PrismTenantSchema>.Succeed(ItemAlias(schema), schema, ChangeType.Import, new List<uSyncChange>());
+    }
+
+    private static Guid DeterministicGuid(string slug)
+    {
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes($"prism-tenant:{slug}"));
+        return new Guid(hash);
+    }
+
+    private static string Slugify(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "unnamed-tenant";
+        var sb = new StringBuilder();
+        var prevHyphen = true;
+        foreach (var ch in name.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch)) { sb.Append(ch); prevHyphen = false; }
+            else if (!prevHyphen) { sb.Append('-'); prevHyphen = true; }
+        }
+        if (sb.Length > 0 && sb[^1] == '-') sb.Length--;
+        return sb.Length > 0 ? sb.ToString() : "unnamed-tenant";
+    }
+
+    private static XElement? NullableElement(string name, string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : new XElement(name, value);
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static bool ParseBool(string? value, bool defaultValue) =>
+        bool.TryParse(value, out var result) ? result : defaultValue;
+
+    private static Dictionary<string, string> ParseOverrides(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new();
+        try { return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new(); }
+        catch { return new(); }
+    }
+}

--- a/src/UmbracoPrism.uSync/SyncHandlers/PrismTenantHandler.cs
+++ b/src/UmbracoPrism.uSync/SyncHandlers/PrismTenantHandler.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Infrastructure.Persistence;
+using uSync.BackOffice;
+using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Services;
+using uSync.BackOffice.SyncHandlers;
+using uSync.BackOffice.SyncHandlers.Interfaces;
+using uSync.BackOffice.SyncHandlers.Models;
+using BackOfficeConsts = global::uSync.BackOffice.uSyncConstants;
+using ISyncItemFactory = global::uSync.Core.ISyncItemFactory;
+using UmbracoPrism.Core.Persistence;
+
+namespace UmbracoPrism.uSync.SyncHandlers;
+
+[SyncHandler("PrismTenantHandler", "Prism Tenants", "Tenants",
+    BackOfficeConsts.Priorites.USYNC_RESERVED_UPPER + 100,
+    Icon = "icon-user",
+    EntityType = "prismTenant")]
+public class PrismTenantHandler : SyncHandlerRoot<PrismTenantSchema, PrismTenantSchema>, ISyncHandler
+{
+    private readonly IUmbracoDatabaseFactory _databaseFactory;
+
+    public override string Group => BackOfficeConsts.Groups.Settings;
+
+    public PrismTenantHandler(
+        ILogger<SyncHandlerRoot<PrismTenantSchema, PrismTenantSchema>> logger,
+        AppCaches appCaches,
+        IShortStringHelper shortStringHelper,
+        ISyncFileService syncFileService,
+        ISyncEventService mutexService,
+        ISyncConfigService uSyncConfig,
+        ISyncItemFactory itemFactory,
+        IUmbracoDatabaseFactory databaseFactory)
+        : base(logger, appCaches, shortStringHelper, syncFileService, mutexService, uSyncConfig, itemFactory)
+    {
+        _databaseFactory = databaseFactory;
+    }
+
+    protected override Task<IEnumerable<PrismTenantSchema>> GetChildItemsAsync(PrismTenantSchema? parent)
+    {
+        if (parent is not null) return Task.FromResult(Enumerable.Empty<PrismTenantSchema>());
+        using var db = _databaseFactory.CreateDatabase();
+        return Task.FromResult<IEnumerable<PrismTenantSchema>>(db.Fetch<PrismTenantSchema>());
+    }
+
+    protected override Task<IEnumerable<PrismTenantSchema>> GetFoldersAsync(PrismTenantSchema? parent) =>
+        Task.FromResult(Enumerable.Empty<PrismTenantSchema>());
+
+    protected override Task<PrismTenantSchema?> GetFromServiceAsync(PrismTenantSchema? item) =>
+        Task.FromResult(default(PrismTenantSchema));
+
+    protected override Task<IEnumerable<uSyncAction>> DeleteMissingItemsAsync(
+        PrismTenantSchema parent, IEnumerable<Guid> keysToKeep, bool reportOnly) =>
+        Task.FromResult(Enumerable.Empty<uSyncAction>());
+
+    protected override string GetItemName(PrismTenantSchema item) => item.Name;
+}

--- a/src/UmbracoPrism.uSync/UmbracoPrism.uSync.csproj
+++ b/src/UmbracoPrism.uSync/UmbracoPrism.uSync.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="uSync.BackOffice" Version="17.3.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UmbracoPrism.Core\UmbracoPrism.Core.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Adds `ITenantTokenResolver` so any tenant identity field (OIDC authority, client ID, secret references, etc.) can hold a `{{TOKEN_NAME}}` placeholder that resolves from appsettings/environment config at runtime, instead of storing secrets/per-environment values directly on the tenant record.
- Adds a `token-status` endpoint and an "Environment Tokens" tab in the create/edit tenant modal so editors can see which placeholders are configured and which are missing.
- Adds the `UmbracoPrism.uSync` project (`PrismTenantHandler` / `PrismTenantSerializer`) so tenants can be exported/imported via uSync; the Hostname field resolves at import time rather than runtime.
- Adds `CLAUDE.md` and `.claude/` tooling config (project guide + `/release` slash command + local permission allowlist) for Claude Code sessions.

## Test plan
- [ ] `dotnet build UmbracoPrism.sln`
- [ ] `dotnet test src/UmbracoPrism.Core.Tests/`
- [ ] Manually verify the "Environment Tokens" tab in the tenant modal against a tenant with `{{TOKEN_NAME}}` placeholders
- [ ] Verify uSync export/import round-trips a tenant correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)