### PR TITLE
feat(editor): persisted canvas layout — drag, cross-lane queue moves, Tidy

### DIFF
--- a/src/UmbracoPrism.Client/src/workflow-editor/README.md
+++ b/src/UmbracoPrism.Client/src/workflow-editor/README.md
@@ -264,3 +264,4 @@ remove or rename without updating the suite in the same commit.**
 | `data-prism-gateway=<gatewayKey>` | Gateway click target + label container. |
 | `data-prism-route-path=<key>` | SVG route path (endpoint assertion). |
 | `data-prism-route-from=<key>` / `data-prism-route-to=<key>` | Route endpoint mapping. |
+| `data-prism-auto-arrange` | Tidy layout HUD button — rewrites every node's position back to the automatic arrangement in one undoable commit. |

--- a/src/UmbracoPrism.Client/src/workflow-editor/graph/graph-app.tsx
+++ b/src/UmbracoPrism.Client/src/workflow-editor/graph/graph-app.tsx
@@ -1,17 +1,20 @@
-import { useMemo, useRef, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import {
   ReactFlow,
   ReactFlowProvider,
+  applyNodeChanges,
   type EdgeTypes,
+  type NodeChange,
   type NodeTypes,
 } from '@xyflow/react';
-import { GraphCallbacksContext, type GraphProps } from './graph-callbacks.js';
-import { buildGraphModel } from './graph-model.js';
+import { GraphCallbacksContext, type GraphNodeMove, type GraphProps } from './graph-callbacks.js';
+import { buildGraphModel, type GraphFlowNode, type GraphModel } from './graph-model.js';
 import type { GraphBridge } from './graph-bridge.js';
 import { StageNode } from './nodes/stage-node.js';
 import { GatewayNode } from './nodes/gateway-node.js';
 import { RouteEdge } from './edges/route-edge.js';
 import { LaneLayer } from './lanes/lane-layer.js';
+import { laneForPosition } from './workflow-graph-layout.js';
 
 const nodeTypes = { stage: StageNode, gateway: GatewayNode } as NodeTypes;
 const edgeTypes = { route: RouteEdge } as EdgeTypes;
@@ -27,21 +30,65 @@ export function GraphApp({ bridge }: { bridge: GraphBridge }) {
   );
 }
 
+/**
+ * The workflow document is the source of truth: local React Flow node state
+ * exists only so in-flight drags render smoothly, and re-seeds whenever the
+ * host pushes a new snapshot (every commit replaces the workflow object).
+ */
+function useControlledNodes(model: GraphModel) {
+  const [nodes, setNodes] = useState(model.nodes);
+  useEffect(() => {
+    setNodes(model.nodes);
+  }, [model]);
+  const onNodesChange = useCallback((changes: NodeChange<GraphFlowNode>[]) => {
+    const positionChanges = changes.filter(change => change.type === 'position');
+    if (positionChanges.length === 0) {
+      return;
+    }
+    setNodes(current => applyNodeChanges(positionChanges, current) as GraphFlowNode[]);
+  }, []);
+  return { nodes, onNodesChange };
+}
+
 function WorkflowGraphCanvas({ bridge, props }: { bridge: GraphBridge; props: GraphProps }) {
   const callbacks = bridge.callbacks;
   const model = useMemo(() => buildGraphModel(props), [props]);
+  const { nodes, onNodesChange } = useControlledNodes(model);
   const readyFired = useRef(false);
+
+  const handleNodeDragStop = useCallback(
+    (_event: unknown, _node: GraphFlowNode, draggedNodes: GraphFlowNode[]) => {
+      const moves: GraphNodeMove[] = draggedNodes.map(dragged => {
+        const width = dragged.width ?? 0;
+        const currentQueue = dragged.data.node.queueKey;
+        const lane = laneForPosition(model.lanes, dragged.position.x + width / 2);
+        return {
+          nodeId: dragged.id,
+          x: dragged.position.x,
+          y: dragged.position.y,
+          queueKey: lane && lane.key !== currentQueue ? lane.key : null,
+        };
+      });
+      if (moves.length > 0) {
+        callbacks.nodesMoved(moves);
+      }
+    },
+    [callbacks, model.lanes]
+  );
 
   return (
     <ReactFlow
-      nodes={model.nodes}
+      nodes={nodes}
       edges={model.edges}
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       minZoom={0.4}
       maxZoom={2}
       defaultViewport={{ x: 0, y: 0, zoom: 1 }}
-      nodesDraggable={false}
+      nodesDraggable={!props.readOnly}
+      nodeDragThreshold={4}
+      onNodesChange={onNodesChange}
+      onNodeDragStop={handleNodeDragStop}
       nodesConnectable={false}
       nodesFocusable={false}
       edgesFocusable={false}

--- a/src/UmbracoPrism.Client/src/workflow-editor/graph/graph-app.tsx
+++ b/src/UmbracoPrism.Client/src/workflow-editor/graph/graph-app.tsx
@@ -57,8 +57,10 @@ function WorkflowGraphCanvas({ bridge, props }: { bridge: GraphBridge; props: Gr
   const readyFired = useRef(false);
 
   const handleNodeDragStop = useCallback(
-    (_event: unknown, _node: GraphFlowNode, draggedNodes: GraphFlowNode[]) => {
-      const moves: GraphNodeMove[] = draggedNodes.map(dragged => {
+    (_event: unknown, node: GraphFlowNode, draggedNodes: GraphFlowNode[]) => {
+      // React Flow only fills the third argument for selection drags.
+      const dragged = draggedNodes.length > 0 ? draggedNodes : [node];
+      const moves: GraphNodeMove[] = dragged.map(dragged => {
         const width = dragged.width ?? 0;
         const currentQueue = dragged.data.node.queueKey;
         const lane = laneForPosition(model.lanes, dragged.position.x + width / 2);

--- a/src/UmbracoPrism.Client/src/workflow-editor/graph/graph-callbacks.ts
+++ b/src/UmbracoPrism.Client/src/workflow-editor/graph/graph-callbacks.ts
@@ -23,6 +23,15 @@ export type GraphContextMenuTarget =
   | { kind: 'stage'; stageKey: string }
   | { kind: 'transition'; transitionIndex: number };
 
+export type GraphNodeMove = {
+  /** Prefixed node id: `stage:<stateKey>` or `gateway:<key>`. */
+  nodeId: string;
+  x: number;
+  y: number;
+  /** Set when the drop landed in a different lane band — the node's queue should be reassigned. */
+  queueKey: string | null;
+};
+
 /**
  * Semantic callbacks from the React canvas back into the Lit wrapper. The
  * canvas interprets pointer/keyboard gestures; the wrapper owns selection
@@ -40,6 +49,8 @@ export type GraphCallbacks = {
     returnTarget?: HTMLElement
   ): void;
   paneClicked(): void;
+  /** One drag gesture ended — commit all moved nodes as a single undoable update. */
+  nodesMoved(moves: GraphNodeMove[]): void;
   laneFocused(lane: { label: string; description: string; stageCount: number }): void;
   zoomChanged(zoom: number): void;
   ready(): void;

--- a/src/UmbracoPrism.Client/src/workflow-editor/graph/graph-model.ts
+++ b/src/UmbracoPrism.Client/src/workflow-editor/graph/graph-model.ts
@@ -90,12 +90,13 @@ export function buildGraphModel(props: GraphProps): GraphModel {
     const placement = layout.placements.get(topologyNode.id);
     const position = placement ? { x: placement.x, y: placement.y } : { x: 0, y: 0 };
     const rowRank = placement?.rowRank ?? 0;
+    // Draggability is governed by the ReactFlow-level nodesDraggable flag
+    // (driven by readOnly) rather than per node.
     const common = {
       id: topologyNode.id,
       position,
       width: topologyNode.width,
       height: topologyNode.height,
-      draggable: false,
       selectable: false,
       focusable: false,
       connectable: false,

--- a/src/UmbracoPrism.Client/src/workflow-editor/graph/workflow-graph-layout-block.ts
+++ b/src/UmbracoPrism.Client/src/workflow-editor/graph/workflow-graph-layout-block.ts
@@ -1,0 +1,82 @@
+import type { AuthoredWorkflow, WorkflowNodePosition } from '../types.js';
+import { workflowGateways } from '../types.js';
+import type { WorkflowQueueDefinition } from '../workflow-stage-assignment.js';
+import {
+  computeDerivedLayout,
+  computeTopology,
+  gatewayNodeId,
+  stageNodeId,
+} from './workflow-graph-layout.js';
+
+/**
+ * Immutable helpers for the definition's `layout` block. Positions are stored
+ * in whole flow pixels keyed by prefixed node id; queue membership stays on
+ * the states/gateways themselves.
+ */
+
+function roundPosition(position: WorkflowNodePosition): WorkflowNodePosition {
+  return { x: Math.round(position.x), y: Math.round(position.y) };
+}
+
+export function getNodePosition(
+  workflow: AuthoredWorkflow,
+  nodeId: string
+): WorkflowNodePosition | null {
+  return workflow.layout?.nodes?.[nodeId] ?? null;
+}
+
+/** Returns a new workflow with the given node positions written into the layout block. */
+export function setNodePositions(
+  workflow: AuthoredWorkflow,
+  positions: Record<string, WorkflowNodePosition>
+): AuthoredWorkflow {
+  const nodes: Record<string, WorkflowNodePosition> = { ...(workflow.layout?.nodes ?? {}) };
+  for (const [nodeId, position] of Object.entries(positions)) {
+    nodes[nodeId] = roundPosition(position);
+  }
+  return pruneLayout({ ...workflow, layout: { nodes } });
+}
+
+/** Drops layout entries whose stage or gateway no longer exists. */
+export function pruneLayout(workflow: AuthoredWorkflow): AuthoredWorkflow {
+  const entries = Object.entries(workflow.layout?.nodes ?? {});
+  if (entries.length === 0) {
+    return workflow.layout === undefined ? workflow : { ...workflow, layout: undefined };
+  }
+
+  const liveIds = new Set<string>([
+    ...workflow.states.map(stage => stageNodeId(stage.stateKey)),
+    ...workflowGateways(workflow).map(gateway => gatewayNodeId(gateway.key)),
+  ]);
+  const nodes: Record<string, WorkflowNodePosition> = {};
+  for (const [nodeId, position] of entries) {
+    if (liveIds.has(nodeId)) {
+      nodes[nodeId] = position;
+    }
+  }
+
+  if (Object.keys(nodes).length === 0) {
+    return { ...workflow, layout: undefined };
+  }
+  return { ...workflow, layout: { nodes } };
+}
+
+/**
+ * Tidy layout: recompute the derived auto-layout for every node (ignoring any
+ * stored positions) and write the result back as explicit positions, so the
+ * arrangement is deterministic and each node stays individually adjustable.
+ */
+export function applyAutoArrange(
+  workflow: AuthoredWorkflow,
+  availableQueues: WorkflowQueueDefinition[] = []
+): AuthoredWorkflow {
+  const layout = computeDerivedLayout(computeTopology(workflow, availableQueues));
+  const nodes: Record<string, WorkflowNodePosition> = {};
+  layout.placements.forEach(placement => {
+    nodes[placement.id] = roundPosition({ x: placement.x, y: placement.y });
+  });
+  if (Object.keys(nodes).length === 0) {
+    return { ...workflow, layout: undefined };
+  }
+  return { ...workflow, layout: { nodes } };
+}

--- a/src/UmbracoPrism.Client/src/workflow-editor/graph/workflow-graph-layout.test.ts
+++ b/src/UmbracoPrism.Client/src/workflow-editor/graph/workflow-graph-layout.test.ts
@@ -4,13 +4,17 @@ import {
   GATEWAY_PILL_HEIGHT,
   GATEWAY_SIZE,
   LANE_HEADER_OFFSET,
+  LANE_INSET,
   TOP_PADDING,
+  computeTopology,
   computeWorkflowGraphLayout,
   laneForPosition,
+  mergeLayout,
   parseGraphNodeId,
   rowBandCenter,
   stageNodeId,
 } from './workflow-graph-layout.js';
+import { applyAutoArrange, pruneLayout, setNodePositions } from './workflow-graph-layout-block.js';
 
 type RawWorkflow = Record<string, unknown>;
 
@@ -225,6 +229,66 @@ export function run(fixtures: LayoutTestFixtures): number {
     check('money-modeller: all six states and six gateways are in the topology',
       topology.nodes.filter(node => node.kind === 'stage').length === 6
       && topology.nodes.filter(node => node.kind === 'gateway').length === 6);
+  }
+
+  // Persisted layout: stored positions override the derived slots, lanes
+  // stretch to cover dragged members, and helpers stay immutable.
+  {
+    const workflow = hydrate(fixtures.paymentDemo);
+    const topology = computeTopology(workflow, []);
+    const derived = mergeLayout(topology, undefined);
+    const firstStageId = stageNodeId(workflow.initialState);
+    const derivedPlacement = derived.placements.get(firstStageId)!;
+
+    const draggedX = derivedPlacement.x + 400;
+    const draggedY = derivedPlacement.y + 500;
+    const moved = setNodePositions(workflow, { [firstStageId]: { x: draggedX + 0.4, y: draggedY - 0.4 } });
+
+    check('layout-block: setNodePositions stores rounded coordinates immutably',
+      moved !== workflow
+      && workflow.layout === undefined
+      && moved.layout?.nodes?.[firstStageId]?.x === draggedX
+      && moved.layout?.nodes?.[firstStageId]?.y === draggedY);
+
+    const merged = mergeLayout(computeTopology(moved, []), moved.layout);
+    const mergedPlacement = merged.placements.get(firstStageId)!;
+    check('layout-block: mergeLayout applies the stored position',
+      mergedPlacement.x === draggedX && mergedPlacement.y === draggedY);
+
+    const lane = merged.lanes.find(candidate => candidate.key === mergedPlacement.queueKey)!;
+    check('layout-block: the lane stretches to keep the dragged node inside its band',
+      mergedPlacement.x >= lane.x + LANE_INSET - 0.001
+      && mergedPlacement.x + mergedPlacement.width <= lane.x + lane.width - LANE_INSET + 0.001);
+
+    check('layout-block: bounds grow with dragged content',
+      merged.bounds.height >= draggedY + mergedPlacement.height + TOP_PADDING
+      && merged.bounds.width >= lane.x + lane.width);
+
+    check('layout-block: untouched nodes keep their derived slots',
+      [...derived.placements.keys()]
+        .filter(id => id !== firstStageId)
+        .every(id => {
+          const before = derived.placements.get(id)!;
+          const after = merged.placements.get(id)!;
+          return before.x === after.x && before.y === after.y;
+        }));
+
+    const pruned = pruneLayout({
+      ...moved,
+      states: moved.states.filter(stage => stage.stateKey !== workflow.initialState),
+    });
+    check('layout-block: pruneLayout drops entries for deleted nodes',
+      pruned.layout === undefined);
+
+    const arranged = applyAutoArrange(moved, []);
+    const arrangedLayout = mergeLayout(computeTopology(arranged, []), arranged.layout);
+    check('layout-block: applyAutoArrange writes explicit derived positions for every node',
+      Object.keys(arranged.layout?.nodes ?? {}).length === topology.nodes.length
+      && [...arrangedLayout.placements.values()].every(placement => {
+        const stored = arranged.layout!.nodes![placement.id];
+        return stored && stored.x === Math.round(derived.placements.get(placement.id)!.x)
+          && stored.y === Math.round(derived.placements.get(placement.id)!.y);
+      }));
   }
 
   // Empty workflow: never throws, produces an empty single-lane-width canvas.

--- a/src/UmbracoPrism.Client/src/workflow-editor/graph/workflow-graph-layout.ts
+++ b/src/UmbracoPrism.Client/src/workflow-editor/graph/workflow-graph-layout.ts
@@ -3,6 +3,7 @@ import type {
   AuthoredStage,
   AuthoredWorkflow,
   RouteView,
+  WorkflowLayoutBlock,
 } from '../types.js';
 import {
   deriveGatewayBindings,
@@ -612,10 +613,64 @@ export function computeDerivedLayout(topology: GraphTopology): WorkflowGraphLayo
   return { placements, lanes, bounds: { width, height } };
 }
 
+/**
+ * Derived layout with stored manual positions applied on top. Lane bands are
+ * elastic: they stretch to cover their members' final positions (a dragged
+ * node widens its lane rather than escaping it), and the canvas bounds grow
+ * with the content. Nodes without a stored position keep their derived slot.
+ */
+export function mergeLayout(
+  topology: GraphTopology,
+  layoutBlock?: WorkflowLayoutBlock | null
+): WorkflowGraphLayout {
+  const derived = computeDerivedLayout(topology);
+  const stored = layoutBlock?.nodes;
+  if (!stored || Object.keys(stored).length === 0) {
+    return derived;
+  }
+
+  const placements = new Map<string, NodePlacement>();
+  derived.placements.forEach((placement, id) => {
+    const override = stored[id];
+    placements.set(
+      id,
+      override ? { ...placement, x: override.x, y: override.y } : placement
+    );
+  });
+
+  const lanes = derived.lanes.map(lane => {
+    const members = [...placements.values()].filter(placement => placement.queueKey === lane.key);
+    if (members.length === 0) {
+      return lane;
+    }
+    const left = Math.min(lane.x, ...members.map(member => member.x - LANE_INSET));
+    const right = Math.max(
+      lane.x + lane.width,
+      ...members.map(member => member.x + member.width + LANE_INSET)
+    );
+    return { ...lane, x: left, width: right - left };
+  });
+
+  const contentBottom = Math.max(
+    derived.bounds.height - TOP_PADDING,
+    ...[...placements.values()].map(placement => placement.y + placement.height)
+  );
+  const contentRight = Math.max(
+    derived.bounds.width - SIDE_PADDING,
+    ...lanes.map(lane => lane.x + lane.width)
+  );
+
+  return {
+    placements,
+    lanes,
+    bounds: { width: contentRight + SIDE_PADDING, height: contentBottom + TOP_PADDING },
+  };
+}
+
 export function computeWorkflowGraphLayout(
   workflow: AuthoredWorkflow | null,
   availableQueues: WorkflowQueueDefinition[] = []
 ): { topology: GraphTopology; layout: WorkflowGraphLayout } {
   const topology = computeTopology(workflow, availableQueues);
-  return { topology, layout: computeDerivedLayout(topology) };
+  return { topology, layout: mergeLayout(topology, workflow?.layout) };
 }

--- a/src/UmbracoPrism.Client/src/workflow-editor/prism-workflow-graph.ts
+++ b/src/UmbracoPrism.Client/src/workflow-editor/prism-workflow-graph.ts
@@ -21,7 +21,9 @@ import { workflowGateways } from './types.js';
 import { gatewayQueueKey } from './workflow-gateway-representation.js';
 import { deleteRoute, flattenRoutes } from './workflow-routes.js';
 import type { GraphBridge } from './graph/graph-bridge.js';
-import type { GraphCallbacks, GraphProps } from './graph/graph-callbacks.js';
+import type { GraphCallbacks, GraphNodeMove, GraphProps } from './graph/graph-callbacks.js';
+import { parseGraphNodeId } from './graph/workflow-graph-layout.js';
+import { applyAutoArrange, pruneLayout, setNodePositions } from './graph/workflow-graph-layout-block.js';
 
 type SelectionKind = 'stage' | 'transition' | 'gateway';
 
@@ -253,6 +255,7 @@ export class PrismWorkflowGraphElement extends LitElement {
         }
       },
       paneClicked: () => this._dismissContextMenu(false),
+      nodesMoved: moves => this._handleNodesMoved(moves),
       laneFocused: lane => this._announce(
         `${lane.label} queue. ${lane.stageCount} stage${lane.stageCount === 1 ? '' : 's'}. ${lane.description}.`
       ),
@@ -321,6 +324,75 @@ export class PrismWorkflowGraphElement extends LitElement {
     this._bridge = null;
     this._bridgeHost = null;
     this.removeAttribute('data-prism-graph-ready');
+  }
+
+  private _currentSelectionDetail(): GraphSelectionDetail | null {
+    if (this._selectedStageKey) {
+      return { kind: 'stage', stageKey: this._selectedStageKey };
+    }
+    if (this._selectedGatewayKey) {
+      return { kind: 'gateway', gatewayKey: this._selectedGatewayKey };
+    }
+    if (this._selectedTransitionIndex !== null) {
+      return { kind: 'transition', transitionIndex: this._selectedTransitionIndex };
+    }
+    return null;
+  }
+
+  private _handleNodesMoved(moves: GraphNodeMove[]) {
+    if (this.readOnly || !this.workflow || moves.length === 0) {
+      return;
+    }
+
+    let next = setNodePositions(
+      this.workflow,
+      Object.fromEntries(moves.map(move => [move.nodeId, { x: move.x, y: move.y }]))
+    );
+
+    const queueMoves = moves.filter(move => move.queueKey);
+    for (const move of queueMoves) {
+      const parsed = parseGraphNodeId(move.nodeId);
+      if (parsed.kind === 'stage') {
+        next = {
+          ...next,
+          states: next.states.map(stage =>
+            stage.stateKey === parsed.key ? applyQueueToStage(stage, move.queueKey!) : stage
+          ),
+        };
+      } else {
+        next = {
+          ...next,
+          gateways: workflowGateways(next).map(gateway =>
+            gateway.key === parsed.key
+              ? { ...gateway, queueKey: move.queueKey!, actor: move.queueKey! }
+              : gateway
+          ),
+        };
+      }
+    }
+
+    this._emitWorkflowUpdated(next, this._currentSelectionDetail());
+
+    if (queueMoves.length > 0) {
+      const first = queueMoves[0];
+      this._announce(
+        `${this._labelForStage(parseGraphNodeId(first.nodeId).key)} moved to the ${this._roleLabelForQueue(first.queueKey!)} queue.`
+      );
+    } else if (moves.length === 1) {
+      this._announce(`${this._labelForStage(parseGraphNodeId(moves[0].nodeId).key)} moved.`);
+    } else {
+      this._announce(`${moves.length} nodes moved.`);
+    }
+  }
+
+  private _tidyLayout() {
+    if (!this.workflow) {
+      return;
+    }
+    const next = applyAutoArrange(this.workflow, this.availableQueues);
+    this._emitWorkflowUpdated(next, this._currentSelectionDetail());
+    this._announce('Canvas tidied — nodes returned to the automatic layout.');
+    requestAnimationFrame(() => this._bridge?.fitView());
   }
 
   private _surfaceForStage(stage: AuthoredStage): StageSurface {
@@ -759,7 +831,7 @@ export class PrismWorkflowGraphElement extends LitElement {
       routes: (stage.routes ?? []).filter(route => route.target !== stageKey),
     }));
 
-    const workflow: AuthoredWorkflow = {
+    const workflow: AuthoredWorkflow = pruneLayout({
       ...this.workflow,
       states: stagesWithRoutes,
       gateways,
@@ -767,7 +839,7 @@ export class PrismWorkflowGraphElement extends LitElement {
         this.workflow.initialState === stageKey
           ? stages[0]?.stateKey ?? ''
           : this.workflow.initialState,
-    };
+    });
 
     this._selectedStageKey = null;
     this._selectedTransitionIndex = null;
@@ -1289,6 +1361,14 @@ export class PrismWorkflowGraphElement extends LitElement {
                   @click=${(event: Event) => this._openCreateGatewayDialog(event.currentTarget as HTMLElement)}
                 >
                   Add gateway
+                </button>
+                <button
+                  type="button"
+                  class="hud-button"
+                  data-prism-auto-arrange
+                  @click=${() => this._tidyLayout()}
+                >
+                  Tidy layout
                 </button>
               </div>
             `}

--- a/src/UmbracoPrism.Client/src/workflow-editor/types.ts
+++ b/src/UmbracoPrism.Client/src/workflow-editor/types.ts
@@ -21,11 +21,28 @@ export interface AuthoredWorkflow {
   gateways?: AuthoredGateway[];
   calculations?: WorkflowCalculationsBlock;
   parameterSchemas?: AuthoredParameterSchema[];
+  layout?: WorkflowLayoutBlock;
   metadata?: WorkflowDefinitionMetadata;
   transitions?: AuthoredTransition[];
   stages?: AuthoredStage[];
   initialStageKey?: string;
   authorNote?: string;
+}
+
+/**
+ * Editor canvas layout hints — manually arranged node positions keyed by
+ * prefixed node id (`stage:<stateKey>` / `gateway:<key>`). Owned by the
+ * editor; the workflow runtime never reads it. Nodes without an entry fall
+ * back to the derived auto-layout, and queue membership (queueKey) stays
+ * authoritative for which swim lane a node belongs to.
+ */
+export interface WorkflowLayoutBlock {
+  nodes?: Record<string, WorkflowNodePosition>;
+}
+
+export interface WorkflowNodePosition {
+  x: number;
+  y: number;
 }
 
 /**
@@ -402,6 +419,7 @@ export function hydrateWorkflowDefinition<T extends AuthoredWorkflow>(workflow: 
       ? root.calculations as WorkflowCalculationsBlock
       : undefined,
     parameterSchemas: asArray<AuthoredParameterSchema>(root.parameterSchemas),
+    layout: sanitiseLayoutBlock(root.layout),
   } as AuthoredWorkflow;
 
   const legacyMetadata: WorkflowDefinitionMetadata = {
@@ -420,6 +438,22 @@ export function hydrateWorkflowDefinition<T extends AuthoredWorkflow>(workflow: 
   defineCompatGetter(normalisedWorkflow, 'transitions', () => buildLegacyTransitions(normalisedWorkflow));
 
   return normalisedWorkflow as T;
+}
+
+function sanitiseLayoutBlock(value: unknown): WorkflowLayoutBlock | undefined {
+  const record = asRecord(value);
+  const nodes = asRecord(record.nodes);
+  const entries: Record<string, WorkflowNodePosition> = {};
+  for (const [key, raw] of Object.entries(nodes)) {
+    const position = asRecord(raw);
+    if (
+      typeof position.x === 'number' && Number.isFinite(position.x)
+      && typeof position.y === 'number' && Number.isFinite(position.y)
+    ) {
+      entries[key] = { x: position.x, y: position.y };
+    }
+  }
+  return Object.keys(entries).length > 0 ? { nodes: entries } : undefined;
 }
 
 function firstString(...values: unknown[]): string | undefined {

--- a/src/UmbracoPrism.Client/src/workflow-editor/workflow-canonical-json.ts
+++ b/src/UmbracoPrism.Client/src/workflow-editor/workflow-canonical-json.ts
@@ -17,6 +17,7 @@ const TOP_LEVEL_KEY_ORDER: readonly string[] = [
   'states',
   'gateways',
   'parameterSchemas',
+  'layout',
 ];
 
 function serialisableRoute(route: AuthoredRoute): Record<string, unknown> {
@@ -82,7 +83,21 @@ function serialisableWorkflow(workflow: AuthoredWorkflow): Record<string, unknow
     gateways: (workflow.gateways ?? []).map(serialisableGateway),
     calculations: workflow.calculations,
     parameterSchemas: workflow.parameterSchemas,
+    layout: serialisableLayout(workflow.layout),
   };
+}
+
+function serialisableLayout(layout: AuthoredWorkflow['layout']): Record<string, unknown> | undefined {
+  const entries = Object.entries(layout?.nodes ?? {});
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const nodes: Record<string, { x: number; y: number }> = {};
+  for (const [key, position] of entries) {
+    // Whole pixels only: drag jitter must never produce spurious dirty state.
+    nodes[key] = { x: Math.round(position.x), y: Math.round(position.y) };
+  }
+  return { nodes };
 }
 
 function orderTopLevel(value: Record<string, unknown>): Record<string, unknown> {

--- a/src/UmbracoPrism.Client/tests/workflow-editor/workflow-canvas-drag.spec.ts
+++ b/src/UmbracoPrism.Client/tests/workflow-editor/workflow-canvas-drag.spec.ts
@@ -1,0 +1,168 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * Manual canvas arrangement: dragging nodes persists positions in the
+ * definition's layout block, dropping into another lane reassigns the queue,
+ * Tidy layout restores the automatic arrangement, and every gesture is a
+ * single undoable history entry.
+ */
+
+const GRAPH_STORY = '/iframe.html?id=workflow-editor-workflow-graph--payment-demo-graph&viewMode=story';
+const EDITOR_STORY = '/iframe.html?id=workflow-editor-editor-host--planning-workflow&viewMode=story';
+
+type LayoutUpdate = {
+  layoutNodeIds: string[];
+  queuesByStage: Record<string, string>;
+};
+
+declare global {
+  interface Window {
+    __layoutUpdates?: LayoutUpdate[];
+  }
+}
+
+async function gotoGraphStory(page: Page, url: string) {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(url);
+  await expect(page.locator('prism-workflow-graph[data-prism-graph-ready="true"]')).toBeAttached({ timeout: 15_000 });
+}
+
+async function recordWorkflowUpdates(page: Page) {
+  await page.locator('prism-workflow-graph').evaluate(graphElement => {
+    window.__layoutUpdates = [];
+    graphElement.addEventListener('workflow-updated', event => {
+      const workflow = (event as CustomEvent<{ workflow: {
+        layout?: { nodes?: Record<string, unknown> };
+        states: Array<{ stateKey: string; queueKey?: string }>;
+      } }>).detail.workflow;
+      window.__layoutUpdates!.push({
+        layoutNodeIds: Object.keys(workflow.layout?.nodes ?? {}),
+        queuesByStage: Object.fromEntries(
+          workflow.states.map(state => [state.stateKey, state.queueKey ?? ''])
+        ),
+      });
+    });
+  });
+}
+
+async function dragBy(page: Page, selector: string, dx: number, dy: number) {
+  const box = await page.locator(`prism-workflow-graph ${selector}`).boundingBox();
+  if (!box) throw new Error(`no bounding box for ${selector}`);
+  const startX = box.x + box.width / 2;
+  const startY = box.y + box.height / 2;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + dx, startY + dy, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForTimeout(200);
+}
+
+test.describe('Workflow canvas — manual arrangement', () => {
+  test('dragging a stage moves it and persists the position in the layout block', async ({ page }) => {
+    await gotoGraphStory(page, GRAPH_STORY);
+    await recordWorkflowUpdates(page);
+
+    const stage = page.locator('prism-workflow-graph [data-prism-stage="enter-details"]');
+    const before = await stage.boundingBox();
+    await dragBy(page, '[data-prism-stage="enter-details"]', 0, 120);
+    const after = await stage.boundingBox();
+
+    expect(after!.y - before!.y, 'the stage must follow the drag').toBeGreaterThan(80);
+
+    const updates = await page.evaluate(() => window.__layoutUpdates!);
+    expect(updates, 'one drag gesture commits exactly one workflow update').toHaveLength(1);
+    expect(updates[0].layoutNodeIds).toContain('stage:enter-details');
+  });
+
+  test('dropping a stage into another lane reassigns its queue in the same commit', async ({ page }) => {
+    await gotoGraphStory(page, GRAPH_STORY);
+    await recordWorkflowUpdates(page);
+
+    const lanes = await page.locator('prism-workflow-graph').evaluate(graphElement => {
+      const root = (graphElement as HTMLElement).shadowRoot!;
+      return Array.from(root.querySelectorAll<HTMLElement>('[data-prism-role-queue]')).map(lane => {
+        const rect = lane.getBoundingClientRect();
+        return { key: lane.getAttribute('data-prism-role-queue') ?? '', centerX: rect.left + rect.width / 2 };
+      });
+    });
+    expect(lanes.length).toBeGreaterThanOrEqual(2);
+
+    const stage = page.locator('prism-workflow-graph [data-prism-stage="enter-details"]');
+    await expect(stage).toHaveAttribute('data-prism-queue', lanes[0].key);
+
+    const box = await stage.boundingBox();
+    await dragBy(page, '[data-prism-stage="enter-details"]', lanes[1].centerX - (box!.x + box!.width / 2), 40);
+
+    await expect(stage).toHaveAttribute('data-prism-queue', lanes[1].key);
+
+    const updates = await page.evaluate(() => window.__layoutUpdates!);
+    expect(updates, 'position + queue reassignment land as a single undoable commit').toHaveLength(1);
+    expect(updates[0].queuesByStage['enter-details']).toBe(lanes[1].key);
+  });
+
+  test('Tidy layout writes explicit positions for every node in one commit', async ({ page }) => {
+    await gotoGraphStory(page, GRAPH_STORY);
+
+    const nodeCount = await page.locator('prism-workflow-graph').evaluate(graphElement => {
+      const root = (graphElement as HTMLElement).shadowRoot!;
+      return root.querySelectorAll('.react-flow__node').length;
+    });
+
+    await dragBy(page, '[data-prism-stage="enter-details"]', 0, 140);
+    await recordWorkflowUpdates(page);
+
+    await page.locator('prism-workflow-graph [data-prism-auto-arrange]').click();
+    await page.waitForTimeout(500);
+
+    const updates = await page.evaluate(() => window.__layoutUpdates!);
+    expect(updates, 'Tidy layout is one commit').toHaveLength(1);
+    expect(updates[0].layoutNodeIds.length, 'every node gets an explicit position').toBe(nodeCount);
+  });
+
+  test('undo restores a dragged stage to its previous position', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto(EDITOR_STORY);
+    await expect(page.locator('prism-workflow-graph[data-prism-graph-ready="true"]')).toBeAttached({ timeout: 15_000 });
+
+    const stageKey = await page.locator('prism-workflow-graph [data-prism-stage]').first()
+      .getAttribute('data-prism-stage');
+    const stage = page.locator(`prism-workflow-graph [data-prism-stage="${stageKey}"]`);
+
+    const before = await stage.boundingBox();
+    await dragBy(page, `[data-prism-stage="${stageKey}"]`, 0, 140);
+    const moved = await stage.boundingBox();
+    expect(moved!.y - before!.y).toBeGreaterThan(100);
+
+    await page.keyboard.press('ControlOrMeta+z');
+    await expect
+      .poll(async () => Math.abs((await stage.boundingBox())!.y - before!.y), {
+        message: 'undo must snap the stage back to its pre-drag position',
+      })
+      .toBeLessThan(2);
+  });
+
+  test('read-only viewer does not allow dragging nodes (the gesture pans instead)', async ({ page }) => {
+    await gotoGraphStory(page, '/iframe.html?id=workflow-editor-workflow-graph--graph-read-only&viewMode=story');
+    await recordWorkflowUpdates(page);
+
+    // Dragging a node in a read-only canvas falls through to a viewport pan,
+    // so screen coordinates move — but the node must not move relative to its
+    // lane, and the workflow document must not change.
+    const stage = page.locator('prism-workflow-graph [data-prism-stage]').first();
+    const lane = page.locator('prism-workflow-graph [data-prism-role-queue]').first();
+    const stageBefore = await stage.boundingBox();
+    const laneBefore = await lane.boundingBox();
+
+    const selector = `[data-prism-stage="${await stage.getAttribute('data-prism-stage')}"]`;
+    await dragBy(page, selector, 0, 120);
+
+    const stageAfter = await stage.boundingBox();
+    const laneAfter = await lane.boundingBox();
+    const relativeBefore = stageBefore!.y - laneBefore!.y;
+    const relativeAfter = stageAfter!.y - laneAfter!.y;
+
+    expect(Math.abs(relativeAfter - relativeBefore), 'read-only canvases must not move nodes within their lane').toBeLessThan(2);
+    expect(await page.evaluate(() => window.__layoutUpdates!.length), 'no workflow mutation in read-only mode').toBe(0);
+  });
+});

--- a/src/UmbracoPrism.Core.Tests/Workflow/Authoring/FourWorkflowReferenceContractTests.cs
+++ b/src/UmbracoPrism.Core.Tests/Workflow/Authoring/FourWorkflowReferenceContractTests.cs
@@ -166,6 +166,16 @@ public class FourWorkflowReferenceContractTests : IClassFixture<FourWorkflowRefe
 
         stage["displayName"] = "Confirm payment received (saved)";
 
+        // The editor persists manual canvas positions in the layout block —
+        // they must survive the save → memory store → reload cycle.
+        payload["layout"] = new JsonObject
+        {
+            ["nodes"] = new JsonObject
+            {
+                ["stage:confirm-payment-received"] = new JsonObject { ["x"] = 620, ["y"] = 480 }
+            }
+        };
+
         try
         {
             using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
@@ -177,6 +187,9 @@ public class FourWorkflowReferenceContractTests : IClassFixture<FourWorkflowRefe
             reloaded.Should().NotBeNull();
             reloaded!.States.Single(state => state.StateKey == "confirm-payment-received")
                 .DisplayName.Should().Be("Confirm payment received (saved)");
+            reloaded.Layout.Should().NotBeNull();
+            reloaded.Layout!.Nodes.Should().ContainKey("stage:confirm-payment-received")
+                .WhoseValue.Should().BeEquivalentTo(new WorkflowNodePosition { X = 620, Y = 480 });
         }
         finally
         {

--- a/src/UmbracoPrism.Core.Tests/Workflow/Components/ComponentPolymorphismTests.cs
+++ b/src/UmbracoPrism.Core.Tests/Workflow/Components/ComponentPolymorphismTests.cs
@@ -364,6 +364,15 @@ public class ComponentPolymorphismTests
             {
                 new() { FromState = "start", ToState = "check", Action = "continue" },
                 new() { FromState = "check", ToState = "complete", Action = "confirm" }
+            },
+            Layout = new WorkflowLayoutDefinition
+            {
+                Nodes = new Dictionary<string, WorkflowNodePosition>
+                {
+                    ["stage:start"] = new() { X = 312, Y = 168 },
+                    ["stage:check"] = new() { X = 312, Y = 472 },
+                    ["gateway:route-from-start"] = new() { X = 356, Y = 320 }
+                }
             }
         };
 
@@ -374,6 +383,8 @@ public class ComponentPolymorphismTests
         // Assert
         deserialized.Should().NotBeNull();
         deserialized.Should().BeEquivalentTo(definition);
+        deserialized!.Layout!.Nodes.Should().ContainKey("gateway:route-from-start")
+            .WhoseValue.Should().BeEquivalentTo(new WorkflowNodePosition { X = 356, Y = 320 });
         json.Should().Contain("\"type\": \"heading\"");
         json.Should().Contain("\"type\": \"body\"");
         json.Should().Contain("\"type\": \"fieldset\"");

--- a/src/UmbracoPrism.Shared/Models/Workflow/WorkflowDefinitionFile.cs
+++ b/src/UmbracoPrism.Shared/Models/Workflow/WorkflowDefinitionFile.cs
@@ -98,6 +98,15 @@ public record WorkflowDefinitionFile
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IReadOnlyDictionary<string, string>? Tags { get; init; }
 
+    /// <summary>
+    /// Editor-owned canvas layout hints: manually arranged node positions
+    /// keyed by prefixed node id (<c>stage:&lt;stateKey&gt;</c> /
+    /// <c>gateway:&lt;key&gt;</c>). The runtime never reads this — it exists
+    /// so authored arrangements survive the save/load round-trip.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public WorkflowLayoutDefinition? Layout { get; init; }
+
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public WorkflowDefinitionMetadata? Metadata { get; init; }
 
@@ -431,4 +440,21 @@ public record WorkflowConditionDefinition
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Description { get; init; }
+}
+
+/// <summary>
+/// Editor canvas layout hints. Positions are whole flow pixels; queue
+/// membership stays authoritative on the states/gateways themselves.
+/// </summary>
+public record WorkflowLayoutDefinition
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, WorkflowNodePosition>? Nodes { get; init; }
+}
+
+public record WorkflowNodePosition
+{
+    public double X { get; init; }
+
+    public double Y { get; init; }
 }


### PR DESCRIPTION
## Summary

PR 2 of the React Flow migration (stacked on #98). Manual canvas arrangement, persisted in the workflow definition.

- **`layout` block in the definition contract** (TS + C#): node positions in whole flow pixels keyed by prefixed node id (`stage:<key>` / `gateway:<key>`). The C# contract is closed (no `JsonExtensionData`), so `WorkflowDefinitionFile` gains a typed `Layout` property — proven to survive the real PUT→GET memory-store cycle by a new end-to-end contract assertion. The runtime never reads it; the publishing projector is deliberately untouched.
- **Auto-layout with manual tweaks**: `mergeLayout` applies stored positions over the derived arrangement; lane bands are elastic (a dragged node widens its lane, never escapes it); nodes without stored positions keep their derived slots.
- **Drag**: one gesture = one `workflow-updated` commit = one undo entry — positions live in the workflow document, so the editor's existing history stack covers moves with zero new host code. Positions are rounded so drag jitter never dirties the document.
- **Cross-lane drop reassigns the queue** (`applyQueueToStage`) in the same undoable commit — drag a stage into another swim lane to move it between queues.
- **Tidy layout** HUD button (`data-prism-auto-arrange`): rewrites every node back to the deterministic auto-layout in one commit, then fits the view.
- Stage deletion prunes orphaned layout entries; the hydrator sanitises malformed layout JSON.

## Tests

- `npm run test:graph-layout` — mergeLayout/setNodePositions/prune/auto-arrange invariants ✅
- New `workflow-canvas-drag.spec.ts` — drag persist, single-commit semantics, cross-lane queue move, Tidy, undo restore, read-only pans-not-moves ✅
- Full Playwright suite: 166 passed / 0 failed; Storybook 56 passed; `dotnet test` 865 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJd2Q8Y2DCtsTMe6Dy4pFE