### PR TITLE
Release: v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Umbraco Prism are documented here. This project follows [semantic versioning](https://semver.org/).
 
+## [v1.13.0] — 2026-07-21
+
+### New Features
+
+- **Document upload and guidance-checklist components for CMS Workflow:** Two new component types — `file-upload` (real disk-backed file storage, with an ownership-checked download link on the review screen) and `guidance-checklist` (a "you must acknowledge every item before continuing" gate, unlike an ordinary checkbox list where any single one satisfies it) — so a CMS Workflow journey can now genuinely collect documents and enforce guidance sign-off.
+- **Member-data defaulting for CMS Workflow:** A signed-in visitor's own data can now default a field's value directly, the same defaulting pattern already available on the other workflow engine.
+- **"Start again" link for terminal single-instance workflows:** A workflow that keeps only one active instance per visitor now offers a real restart link once it reaches a dead-end state, instead of requiring a visitor to clear cookies to try again.
+
+---
+
 ## [v1.12.0] — 2026-07-19
 
 ### New Features

--- a/src/UmbracoPrism.Client/package.json
+++ b/src/UmbracoPrism.Client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "umbracoprism-client",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
+++ b/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>UmbracoPrism</PackageId>
     <Title>Umbraco Prism</Title>
-    <Version>1.12.0</Version>
+    <Version>1.13.0</Version>
     <Authors>Jonny Muir</Authors>
     <Company>Umbraco Prism</Company>
     <Description>Multi-tenancy for Umbraco (v17+) with dynamic branding and stateless identity.</Description>


### PR DESCRIPTION
## Summary

**Minor release** — driven by two `feat:` commits since v1.12.0 (new file-upload/guidance-checklist CMS Workflow components; no breaking changes).

## Release notes

### New Features

- **Document upload and guidance-checklist components for CMS Workflow:** Two new component types — `file-upload` (real disk-backed file storage, with an ownership-checked download link on the review screen) and `guidance-checklist` (a "you must acknowledge every item before continuing" gate, unlike an ordinary checkbox list where any single one satisfies it) — so a CMS Workflow journey can now genuinely collect documents and enforce guidance sign-off.
- **Member-data defaulting for CMS Workflow:** A signed-in visitor's own data can now default a field's value directly, the same defaulting pattern already available on the other workflow engine.
- **"Start again" link for terminal single-instance workflows:** A workflow that keeps only one active instance per visitor now offers a real restart link once it reaches a dead-end state, instead of requiring a visitor to clear cookies to try again.

## Post-merge

After this PR is merged to main, tag the merge commit to trigger the NuGet publish:

```bash
git checkout main && git pull
git tag v1.13.0
git push origin v1.13.0
```

This triggers `package-release.yml` which builds, packs, and publishes the NuGet package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFkBGMUmY8gxspjrPdFB4Q