### PR TITLE
fix: CMS Workflow workspace scrolling + reliable demo terminal recording

### DIFF
--- a/.claude/skills/narrated-single-take-demo-recording/SKILL.md
+++ b/.claude/skills/narrated-single-take-demo-recording/SKILL.md
@@ -81,7 +81,35 @@ to get wrong.
   Run headed for any take with more than a couple of minutes of passive waiting; a small periodic
   `page.mouse.move` nudge is cheap extra insurance but headed mode is the actual fix.
 
-### ttyd: `--writable`, restrict `--tools` to the exact toolset, `bypassPermissions`
+### Preferred terminal surface: a tmux capture-pane DOM mirror, not ttyd/xterm in the browser
+
+Driving ttyd/xterm.js inside the recorded page failed in ways assertions can't catch: a terminal
+whose grid was computed at one font metric but painted at another (tiny text in a corner of a
+1080p frame), a huge unpainted grey canvas band, and the canvas visibly freezing for minutes
+mid-take while the underlying session kept working. The replacement
+(`tests/demo/support/tmux-terminal.ts`, first used by `licence-transfer-demo.spec.ts`): run the
+real session in tmux on a dedicated socket (`tmux -L <socket>`), send input via
+`tmux send-keys`, and render a styled DOM mirror of `tmux capture-pane -e` output into the
+recorded page (about:blank) on a ~300ms poll — ANSI SGR converted to HTML spans, cursor overlay
+positioned from tmux's own `#{cursor_x}/#{cursor_y}` in `ch` units. Because capture-pane reads
+tmux's virtual screen, even a full-screen TUI (Claude Code's) mirrors perfectly; there is no
+focus to lose, no password, no font negotiation, and no canvas to freeze. Three hard-won
+sub-lessons baked into that module and its spec:
+
+- **tmux `send-keys` silently swallows a bare `;`** — it parses a lone `;` argument as its own
+  command separator even after `--` and with `-l`. Escape as `\;` or a
+  `remove ...; add ...` command line collapses into one broken command (this cost three takes).
+- **Pin the spawned agent's model** (`claude --model sonnet ...`) — otherwise it inherits
+  whatever personal default the operator's claude config has that day.
+- **Probe service ports with the exact auth + grant the real consumer will use** (a full
+  authenticated MCP `initialize` with a client-credentials token), and add fail-fast connectivity
+  guards before the agent launches — a stale orphaned host process answers a generic
+  unauthenticated 401 probe convincingly while rejecting real tokens, and a UI session token is
+  not interchangeable with a client-credentials one.
+
+The ttyd notes below remain for the older garden-waste spec, which still uses it.
+
+### ttyd (legacy — garden-waste demo only): `--writable`, restrict `--tools`, `bypassPermissions`
 
 - `--writable` — ttyd defaults read-only; without it the whole hand-off act is inert.
 - `--tools "mcp__yourserver__*,..."` restricts the *entire available toolset*, not an allow-list on

--- a/src/UmbracoPrism.Client/src/backoffice/cms-workflow/workspace/cms-workflow-workspace-editor.element.ts
+++ b/src/UmbracoPrism.Client/src/backoffice/cms-workflow/workspace/cms-workflow-workspace-editor.element.ts
@@ -78,15 +78,30 @@ export class PrismCmsWorkflowWorkspaceEditorElement extends UmbElementMixin(LitE
   }
 
   static styles = css`
+    /* The routable workspace mounts this element directly into a clipped, fixed-height
+       region — nothing above it in the backoffice chain scrolls (umb-workspace-editor,
+       which normally provides the scrollable body, isn't in play here). The editor lays
+       out at natural content height (its own height: 100% resolves against this auto-height
+       chain), so without a scroll container of our own the content below the fold is simply
+       unreachable. Make this host the scroll container — the same end state as the old
+       Prism-section tab wrapper's fix, adapted to workspace hosting. */
     :host {
       display: block;
       width: 100%;
-      min-height: 70vh;
+      height: 100%;
+      overflow-y: auto;
     }
 
+    /* Outer-tree declarations beat the editor's own :host rules, which hard-code
+       height: 100% + overflow: hidden for viewport-owning hosts. Here that combination
+       would resolve against this host's now-definite height and clip the editor to
+       exactly the container — leaving nothing for the scroll container above to scroll.
+       Force natural content height instead. */
     prism-workflow-editor {
       display: block;
+      height: auto;
       min-height: 70vh;
+      overflow: visible;
     }
   `;
 }

--- a/src/UmbracoPrism.Client/tests/demo/README.md
+++ b/src/UmbracoPrism.Client/tests/demo/README.md
@@ -65,6 +65,17 @@ it for cross-test pages.
 
 ## Setup
 
+> **These ttyd steps apply to the garden-waste demo (`npm run demo:record`) only.** The
+> licence-transfer demo (`npm run demo:record:licence-transfer`) no longer uses ttyd at all: its
+> terminal is a plain tmux session the spec starts itself, mirrored into the recorded page as
+> styled DOM (`support/tmux-terminal.ts`) — no password, no manual terminal setup, no extra env
+> vars. Just start Aspire (with `PRISM_TESTSITE_RESET_RUNTIME=true
+> Umbraco__CMS__Global__TimeOut=02:00:00` for a real take) and run the npm script. The switch was
+> deliberate: driving ttyd/xterm.js in the recorded browser produced mis-sized text, unpainted
+> grey canvas regions, and multi-minute visual freezes that assertions can't catch — a
+> capture-pane-fed DOM mirror can't desync from the real session and renders at exactly the font
+> size the recording needs.
+
 Note: The ttyd is strickly just so we can automate the recording. If you want to do this as a manual walkthrough you do not need it, this is just your AI tool of choice, e.g. ```claude```
 
 1. **Warm the stack first, off-camera.** Start Aspire and wait for the dashboard to go green —

--- a/src/UmbracoPrism.Client/tests/demo/licence-transfer-demo.spec.ts
+++ b/src/UmbracoPrism.Client/tests/demo/licence-transfer-demo.spec.ts
@@ -1,10 +1,17 @@
 import { test, expect, type Page, type Locator } from '@playwright/test';
-import { execFileSync, spawn } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { beat, showSlate, clearSlate, moveNarrationTo, startNarrationTimeline, getNarrationTimeline } from './support/narration';
 import { humanClick, humanType, humanMoveTo } from './support/human-interactions';
+import {
+  startDemoTerminalSession,
+  showTerminalMirror,
+  stopTerminalMirror,
+  sendTerminalText,
+  sendTerminalKey
+} from './support/tmux-terminal';
 
 // Sibling of garden-waste-demo.spec.ts and (the now-removed) pension-bereavement-demo.spec.ts —
 // same one-page/one-video technique, same narration/human-interaction helpers. The story this one
@@ -33,8 +40,9 @@ function tryConvertToMp4(webmPath: string): void {
 }
 
 // Not a CI test — a demo-recording tool. Run with:
-//   TTYD_PASSWORD=<password> npm run demo:record:licence-transfer
-// See tests/demo/README.md for the ttyd/tmux mechanics shared with the other demos, and
+//   npm run demo:record:licence-transfer
+// The terminal acts run in a plain tmux session mirrored into the recorded page as styled DOM
+// (see support/tmux-terminal.ts for why that replaced ttyd/xterm). See
 // docs/demos/licence-transfer-mcp-walkthrough.md for the full narrated storyboard this spec
 // follows act-for-act.
 //
@@ -56,8 +64,6 @@ const mcpClientId = 'prism-mcp-agent';
 const mcpClientSecret = 'prism-mcp-agent-demo-secret-2026';
 const prefixedMcpClientId = `umbraco-back-office-${mcpClientId}`;
 
-const ttydUrl = process.env.TTYD_URL ?? 'http://127.0.0.1:7681';
-const ttydPort = new URL(ttydUrl).port || '7681';
 const claudeSessionLogPath = '/tmp/claude-session.log';
 const scratchDir = path.join(process.env.HOME ?? '/tmp', 'prism-demo-scratch');
 
@@ -222,70 +228,66 @@ async function ensureMcpServiceAccount(page: Page, backofficeToken: string): Pro
 }
 
 /** Finds TestSite's real plain-HTTP MCP port — dynamic per Aspire run, distinct from the fixed HTTPS one. */
-function discoverCmsWorkflowMcpHttpPort(): number {
-  const pid = execFileSync('bash', ['-c', "ps aux | grep 'UmbracoPrism.TestSite/bin' | grep -v grep | awk '{print $2}'"])
+/**
+ * True only if this port hosts the *live* MCP endpoint AND accepts the given bearer token — a
+ * full authenticated `initialize` round trip, not a weaker liveness signal. A bare unauthenticated
+ * probe (does it answer 401?) once picked a stale, orphaned TestSite from an earlier boot: it
+ * happily answered 401 (any backoffice-auth'd ASP.NET app does), but rejected the freshly-minted
+ * token (different signing keys), so the agent's MCP client showed "Failed to connect" and the
+ * agent launched with no tools at all — hallucinating tool-call syntax as plain text.
+ */
+function probeMcpInitialize(port: number, bearerToken: string): boolean {
+  try {
+    const status = execFileSync('curl', [
+      '-s', '-o', '/dev/null', '-w', '%{http_code}', '--max-time', '3',
+      '-X', 'POST', `http://localhost:${port}/prism/workflow-authoring/mcp`,
+      '-H', `Authorization: Bearer ${bearerToken}`,
+      '-H', 'Content-Type: application/json',
+      '-H', 'Accept: application/json, text/event-stream',
+      '-d', '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"demo-probe","version":"1.0"}}}'
+    ]).toString();
+    return status === '200';
+  } catch {
+    return false;
+  }
+}
+
+function discoverCmsWorkflowMcpHttpPort(bearerToken: string): number {
+  // Every matching pid, not just the first — a stale orphaned TestSite from an earlier boot can
+  // legitimately coexist with the live one for a while, and which `ps` lists first is luck.
+  const pids = execFileSync('bash', ['-c', "ps aux | grep 'UmbracoPrism.TestSite/bin' | grep -v grep | awk '{print $2}'"])
     .toString()
     .trim()
-    .split('\n')[0];
-  if (!pid) throw new Error('Could not find the running TestSite process to discover its MCP port.');
+    .split('\n')
+    .filter(Boolean);
+  if (pids.length === 0) throw new Error('Could not find a running TestSite process to discover its MCP port.');
 
-  const lsofOutput = execFileSync('bash', ['-c', `lsof -p ${pid} -a -i -P 2>/dev/null | grep LISTEN`]).toString();
-  const ports = Array.from(lsofOutput.matchAll(/localhost:(\d+)/g)).map(m => Number(m[1]));
-  const uniquePorts = Array.from(new Set(ports));
-
-  for (const port of uniquePorts) {
+  const uniquePorts = new Set<number>();
+  for (const pid of pids) {
     try {
-      const status = execFileSync('curl', [
-        '-s', '-o', '/dev/null', '-w', '%{http_code}',
-        '--max-time', '3', `http://localhost:${port}/prism/workflow-authoring/mcp`
-      ]).toString();
-      if (status === '401') return port; // The real HTTP MCP endpoint answers 401 with no token.
+      const lsofOutput = execFileSync('bash', ['-c', `lsof -p ${pid} -a -i -P 2>/dev/null | grep LISTEN`]).toString();
+      for (const match of lsofOutput.matchAll(/localhost:(\d+)/g)) {
+        uniquePorts.add(Number(match[1]));
+      }
     } catch {
-      // Not this port — try the next.
+      // Process may have just exited — skip it.
     }
   }
-  throw new Error(`Could not find the CMS Workflow MCP HTTP port among: ${uniquePorts.join(', ')}`);
+
+  for (const port of uniquePorts) {
+    if (probeMcpInitialize(port, bearerToken)) return port;
+  }
+  throw new Error(
+    `No port among [${Array.from(uniquePorts).join(', ')}] completed an authenticated MCP initialize — ` +
+    'is the token valid against the currently-running TestSite?'
+  );
 }
 
 /**
- * Starts the ttyd/tmux terminal surface, wrapping a *plain shell* (not claude directly) — the
- * whole point is that Act 1's real auth setup (token exchange, `claude mcp add`) happens as real,
- * visible commands in this same terminal before claude itself ever launches, rather than
- * happening invisibly via network calls the audience never sees. `script` starts recording from
- * the very first command, so the eventual claude launch (and its one-time consent gate) is
- * captured in the log same as everything else. Stripping CLAUDECODE/CLAUDE_CODE_* env vars keeps
- * the later-launched claude a genuinely independent process, not a child of this one.
- */
-function startTtydTerminal(ttydPassword: string): void {
-  const strippedEnv = Object.fromEntries(
-    Object.entries(process.env).filter(([key]) => !/^(CLAUDECODE|CLAUDE_CODE_|AI_AGENT|CLAUDE_EFFORT)/.test(key))
-  );
-  const child = spawn(
-    'ttyd',
-    [
-      '--writable', '--interface', '127.0.0.1', '-p', ttydPort, '-c', `demo:${ttydPassword}`,
-      'tmux', 'new-session', '-A', '-s', 'prism-licence-transfer-demo', '--',
-      'script', '-q', '-F', claudeSessionLogPath, 'bash'
-    ],
-    { cwd: scratchDir, env: strippedEnv, detached: true, stdio: 'ignore' }
-  );
-  child.unref();
-}
-
-/** Connects (or reconnects) to the shared terminal page — no bypass-gate check here, since that
- * gate can only appear once claude has actually been launched (see handleBypassPermissionsGate). */
-async function connectToTerminal(page: Page): Promise<void> {
-  await page.goto(ttydUrl, { waitUntil: 'networkidle', timeout: 15_000 });
-  await page.waitForTimeout(2_000);
-  await humanClick(page, page.locator('.xterm-screen'));
-  await page.waitForTimeout(500);
-}
-
-/**
- * ttyd's xterm.js renders to canvas, not DOM text, so the only way to detect the one-time
- * BypassPermissions consent gate is via the tee'd session log, and only answer it if it's
- * actually showing (blindly sending "2"+Enter on a visit where the gate isn't showing types a
- * literal "2" into a live empty prompt and visibly confuses whatever's running).
+ * The one-time BypassPermissions consent gate can only be detected via the `script`-tee'd
+ * session log — and should only be answered if it's actually showing (blindly sending "2"+Enter
+ * on a visit where the gate isn't showing types a literal "2" into a live empty prompt and
+ * visibly confuses whatever's running).
  */
 async function handleBypassPermissionsGateIfShowing(page: Page): Promise<void> {
   let recentLog = '';
@@ -295,18 +297,17 @@ async function handleBypassPermissionsGateIfShowing(page: Page): Promise<void> {
     // No log yet — nothing to detect either way.
   }
   if (/Yes, I accept|No, exit/i.test(recentLog)) {
-    await page.keyboard.press('2');
-    await page.keyboard.press('Enter');
+    sendTerminalKey('2');
+    sendTerminalKey('Enter');
     await page.waitForTimeout(1_000);
   }
 }
 
-/** Types a real command into the currently-focused terminal, character by character (matching
- * the brief-typing pace elsewhere), then presses Enter. */
-async function typeInTerminal(page: Page, command: string, delay = 18): Promise<void> {
-  await page.keyboard.type(command, { delay });
+/** Types a real command into the tmux session, character by character, then presses Enter. */
+async function typeInTerminal(page: Page, command: string, delay = 10): Promise<void> {
+  await sendTerminalText(command, delay);
   await page.waitForTimeout(300);
-  await page.keyboard.press('Enter');
+  sendTerminalKey('Enter');
 }
 
 // ------------------------------------------------------------------ Act 5 helpers: generic form filling
@@ -515,39 +516,20 @@ async function answerEligibilityQuestion(page: Page, eligible: boolean): Promise
 test.describe.serial('licence transfer demo', () => {
   let page: Page;
   let mintedToken: string;
-  let ttydPassword: string;
+  let mcpPort: number;
 
   test.beforeAll(async ({ browser }) => {
-    if (!process.env.TTYD_PASSWORD) {
-      throw new Error('Set TTYD_PASSWORD to the password ttyd should use for this take — see README.md.');
-    }
-    ttydPassword = process.env.TTYD_PASSWORD;
-
     const recordingSize = { width: 1920, height: 1080 };
     const context = await browser.newContext({
       viewport: recordingSize,
-      recordVideo: { dir: footageDir, size: recordingSize },
-      httpCredentials: { username: 'demo', password: ttydPassword, origin: new URL(ttydUrl).origin }
+      recordVideo: { dir: footageDir, size: recordingSize }
     });
     page = await context.newPage();
     startNarrationTimeline();
-
-    // Bigger ttyd terminal text — same window.term hook as the other demos.
-    await page.addInitScript(ttydOrigin => {
-      if (window.location.origin !== ttydOrigin) return;
-      let liveTerm: { options: Record<string, unknown> } | undefined;
-      Object.defineProperty(window, 'term', {
-        configurable: true,
-        get: () => liveTerm,
-        set: (value: { options: Record<string, unknown> }) => {
-          liveTerm = value;
-          if (value?.options) value.options.fontSize = 26;
-        }
-      });
-    }, new URL(ttydUrl).origin);
   });
 
   test.afterAll(async () => {
+    stopTerminalMirror();
     const video = page?.video();
     await page?.close();
     if (video) {
@@ -605,11 +587,30 @@ test.describe.serial('licence transfer demo', () => {
 
     const backofficeToken = await captureBearerToken(page);
     await ensureMcpServiceAccount(page, backofficeToken);
-    const port = discoverCmsWorkflowMcpHttpPort();
+    // Discovery probes with a throwaway client-credentials token minted off-camera — the SAME
+    // grant the on-camera terminal command mints moments later. The browser session's own
+    // backoffice token does NOT pass the MCP endpoint's auth (confirmed live: UI token → 401,
+    // client-credentials token → 200), and probing with the exact token kind the agent will use
+    // is what proves the port belongs to the currently-running TestSite rather than a stale
+    // orphan from an earlier boot (see probeMcpInitialize).
+    const probeTokenJson = execFileSync('curl', [
+      '-sk', '-X', 'POST', `${testSiteOrigin}/umbraco/management/api/v1/security/back-office/token`,
+      '-d', 'grant_type=client_credentials',
+      '-d', `client_id=${prefixedMcpClientId}`,
+      '-d', `client_secret=${mcpClientSecret}`
+    ]).toString();
+    const probeToken = (JSON.parse(probeTokenJson) as { access_token?: string }).access_token;
+    if (!probeToken) throw new Error(`Off-camera client-credentials mint failed: ${probeTokenJson.slice(0, 200)}`);
+    const port = discoverCmsWorkflowMcpHttpPort(probeToken);
+    mcpPort = port;
 
-    startTtydTerminal(ttydPassword);
+    // The terminal is a plain tmux session wrapping `script` + bash — Act 1's real auth setup
+    // (token exchange, `claude mcp add`) happens as real, visible commands in it before claude
+    // itself ever launches, and `script` captures everything (including the later claude launch
+    // and its one-time consent gate) to the session log from the very first command.
+    startDemoTerminalSession(claudeSessionLogPath, scratchDir);
     await page.waitForTimeout(2_000);
-    await connectToTerminal(page);
+    await showTerminalMirror(page);
     await moveNarrationTo(page, 'top');
 
     await beat(
@@ -653,6 +654,13 @@ test.describe.serial('licence transfer demo', () => {
     const tokenFileContents = JSON.parse(readFileSync(tokenFilePath, 'utf8')) as { access_token: string };
     mintedToken = tokenFileContents.access_token;
 
+    // Fail the take in seconds, not after a 40-minute poll: the token the terminal just
+    // registered with claude must complete a real MCP initialize against the same port.
+    expect(
+      probeMcpInitialize(port, mintedToken),
+      `the minted token failed an MCP initialize against port ${port} — the agent would launch with no working tools`
+    ).toBe(true);
+
     await beat(
       page,
       'recap',
@@ -670,7 +678,14 @@ test.describe.serial('licence transfer demo', () => {
     // trigger-based routing, taking 26+ minutes; another took under 8. Budget generously.
     test.setTimeout(45 * 60_000);
 
-    await connectToTerminal(page);
+    // Same guard as Act 1's end — don't let the agent launch against a connection that has
+    // silently gone bad in between (expired token, restarted host).
+    expect(
+      probeMcpInitialize(mcpPort, mintedToken),
+      `MCP initialize against port ${mcpPort} stopped working between acts — aborting before wasting an agent run`
+    ).toBe(true);
+
+    await showTerminalMirror(page);
     await handleBypassPermissionsGateIfShowing(page);
     await moveNarrationTo(page, 'top');
 
@@ -682,7 +697,11 @@ test.describe.serial('licence transfer demo', () => {
     );
     await typeInTerminal(
       page,
-      'claude --tools "mcp__prism-cms-workflow__*,ListMcpResourcesTool,ReadMcpResourceDirTool,ReadMcpResourceTool" --permission-mode bypassPermissions'
+      // --model pinned explicitly: the spawned agent otherwise inherits whatever default the
+      // operator's own claude config happens to have at the time — a take died mid-build when a
+      // freshly-switched personal default model stalled after its first tool call. The demo's
+      // agent should behave identically regardless of who records it.
+      'claude --model sonnet --tools "mcp__prism-cms-workflow__*,ListMcpResourcesTool,ReadMcpResourceDirTool,ReadMcpResourceTool" --permission-mode bypassPermissions'
     );
     await page.waitForTimeout(3_000);
     await handleBypassPermissionsGateIfShowing(page);
@@ -694,9 +713,9 @@ test.describe.serial('licence transfer demo', () => {
       { position: 'top' }
     );
 
-    await page.keyboard.type(brief, { delay: 22 });
+    await sendTerminalText(brief, 10);
     await page.waitForTimeout(400);
-    await page.keyboard.press('Enter');
+    sendTerminalKey('Enter');
 
     await beat(
       page,
@@ -706,8 +725,8 @@ test.describe.serial('licence transfer demo', () => {
     );
 
     // The real completion signal is the saved definition itself, authenticated with the same
-    // token Act 1 minted — not anything printed in the terminal (ttyd's xterm.js renders to
-    // canvas, not DOM text, so there's nothing reliable to scrape there anyway).
+    // token Act 1 minted — not anything printed in the terminal (matching agent output text is
+    // inherently fragile; the saved definition is the fact that can only become true for real).
     await expect.poll(
       async () => {
         const response = await request.get(
@@ -735,6 +754,9 @@ test.describe.serial('licence transfer demo', () => {
       'And there it is — designed, validated, simulated, and saved to the live engine. No one wrote a line of this workflow by hand.',
       { position: 'top' }
     );
+
+    // The recording is done with the terminal from here on — later acts are all backoffice/site.
+    stopTerminalMirror();
   });
 
   const navLinkLabel = 'Transfer your licence';

--- a/src/UmbracoPrism.Client/tests/demo/support/tmux-terminal.ts
+++ b/src/UmbracoPrism.Client/tests/demo/support/tmux-terminal.ts
@@ -1,0 +1,317 @@
+import { execFileSync, spawn } from 'node:child_process';
+import type { Page } from '@playwright/test';
+
+// A recording-friendly terminal surface: the real session lives in tmux (on its own socket, so
+// its environment and lifecycle are fully ours), input goes in via `tmux send-keys`, and the
+// recorded page renders a styled mirror of `tmux capture-pane` output as plain DOM.
+//
+// This replaces driving ttyd/xterm.js in the recorded browser, which failed in ways that were
+// invisible to assertions and fatal to footage: the font-size hook produced a terminal whose
+// grid was computed at one font metric and painted at another (tiny text in a corner of the
+// screen, a huge unpainted grey band below it), and the canvas visibly froze for minutes at a
+// time mid-recording while the underlying session kept working. A DOM mirror fed from
+// capture-pane cannot desync from the real session, needs no focus, renders at exactly the
+// font size we choose, and has no canvas to freeze.
+
+const SOCKET = 'prism-demo';
+const SESSION = 'prism-demo-terminal';
+
+// 150×36 at 20px/27px Menlo fills a 1920×1080 frame (minus title bar and padding) almost
+// exactly — chosen together with the CSS in installMirrorChrome below.
+export const TERMINAL_COLS = 150;
+export const TERMINAL_ROWS = 36;
+
+function tmux(...args: string[]): string {
+  // stderr piped (not inherited) so an expected first-call failure like "no server running"
+  // doesn't leak noise into the test reporter's output.
+  return execFileSync('tmux', ['-L', SOCKET, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/**
+ * Kills any previous demo terminal server and starts a fresh session of exactly
+ * TERMINAL_COLS×TERMINAL_ROWS, wrapping `script` so everything (including a later claude
+ * launch and its one-time consent gate) is captured to `logPath` from the very first command.
+ * CLAUDECODE/CLAUDE_CODE_* env vars are stripped so a claude launched inside is a genuinely
+ * independent process, not a child session of the recording orchestrator.
+ */
+export function startDemoTerminalSession(logPath: string, cwd: string): void {
+  try {
+    tmux('kill-server');
+  } catch {
+    // No server running — nothing to kill.
+  }
+  const strippedEnv = Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([key]) => !/^(CLAUDECODE|CLAUDE_CODE_|AI_AGENT|CLAUDE_EFFORT)/.test(key)
+    )
+  ) as NodeJS.ProcessEnv;
+  const child = spawn(
+    'tmux',
+    [
+      '-L', SOCKET,
+      'new-session', '-d', '-s', SESSION,
+      '-x', String(TERMINAL_COLS), '-y', String(TERMINAL_ROWS),
+      '-c', cwd,
+      'script', '-q', '-F', logPath, 'bash'
+    ],
+    { env: strippedEnv, stdio: 'ignore' }
+  );
+  child.unref();
+  // The session was created with the status bar counted inside the -y height; turning it off
+  // gives the pane the full TERMINAL_ROWS. Retry briefly — the server may still be starting.
+  const deadline = Date.now() + 5_000;
+  for (;;) {
+    try {
+      tmux('set-option', '-g', 'status', 'off');
+      break;
+    } catch {
+      if (Date.now() > deadline) throw new Error('tmux demo server did not start in time');
+    }
+  }
+}
+
+/** Sends literal text to the session, one character at a time, at a human-looking pace. */
+export async function sendTerminalText(text: string, delayMs = 8): Promise<void> {
+  for (const ch of text) {
+    // tmux parses a lone ";" argument as its own command separator BEFORE send-keys sees it —
+    // even after "--" and even with -l — so a bare semicolon is silently swallowed. This cost a
+    // full recorded take: a `remove ...; add ...` command line lost its ";", collapsed into one
+    // broken command whose errors were hidden by 2>/dev/null, and the MCP registration it was
+    // supposed to perform never happened. "\;" is tmux's documented escape for a literal one.
+    tmux('send-keys', '-t', SESSION, '-l', '--', ch === ';' ? '\\;' : ch);
+    await new Promise(resolve => setTimeout(resolve, delayMs));
+  }
+}
+
+/** Sends a named key (Enter, Escape, C-c, ...) to the session. */
+export function sendTerminalKey(key: string): void {
+  tmux('send-keys', '-t', SESSION, key);
+}
+
+/** The visible pane content, with SGR colour escapes preserved for the mirror to render. */
+export function captureTerminal(): string {
+  return tmux('capture-pane', '-p', '-e', '-t', SESSION);
+}
+
+function cursorPosition(): { x: number; y: number; visible: boolean } {
+  try {
+    const raw = tmux('display-message', '-p', '-t', SESSION, '#{cursor_x} #{cursor_y} #{cursor_flag}').trim();
+    const [x, y, flag] = raw.split(/\s+/).map(Number);
+    return { x: x || 0, y: y || 0, visible: flag !== 0 };
+  } catch {
+    return { x: 0, y: 0, visible: false };
+  }
+}
+
+// ------------------------------------------------------------------ ANSI → HTML
+
+// GitHub-dark-flavoured 16-colour palette — legible on the mirror's near-black background.
+const BASE_COLORS = [
+  '#21262d', '#f47067', '#57ab5a', '#c69026', '#539bf5', '#b083f0', '#39c5cf', '#adbac7',
+  '#545d68', '#ff938a', '#6bc46d', '#daaa3f', '#6cb6ff', '#dcbdfb', '#56d4dd', '#cdd9e5'
+];
+
+function xterm256(n: number): string {
+  if (n < 16) return BASE_COLORS[n];
+  if (n < 232) {
+    const idx = n - 16;
+    const steps = [0, 95, 135, 175, 215, 255];
+    const r = steps[Math.floor(idx / 36)];
+    const g = steps[Math.floor(idx / 6) % 6];
+    const b = steps[idx % 6];
+    return `rgb(${r},${g},${b})`;
+  }
+  const v = 8 + (n - 232) * 10;
+  return `rgb(${v},${v},${v})`;
+}
+
+interface SgrState {
+  bold: boolean;
+  dim: boolean;
+  italic: boolean;
+  underline: boolean;
+  reverse: boolean;
+  fg: string | null;
+  bg: string | null;
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function styleFor(state: SgrState): string {
+  let fg = state.fg;
+  let bg = state.bg;
+  if (state.reverse) {
+    [fg, bg] = [bg ?? '#e6edf3', fg ?? '#101418'];
+  }
+  const parts: string[] = [];
+  if (fg) parts.push(`color:${fg}`);
+  if (bg) parts.push(`background:${bg}`);
+  if (state.bold) parts.push('font-weight:600');
+  if (state.dim) parts.push('opacity:.62');
+  if (state.italic) parts.push('font-style:italic');
+  if (state.underline) parts.push('text-decoration:underline');
+  return parts.join(';');
+}
+
+function applySgr(state: SgrState, params: number[]): void {
+  for (let i = 0; i < params.length; i++) {
+    const p = params[i];
+    if (p === 0) Object.assign(state, { bold: false, dim: false, italic: false, underline: false, reverse: false, fg: null, bg: null });
+    else if (p === 1) state.bold = true;
+    else if (p === 2) state.dim = true;
+    else if (p === 3) state.italic = true;
+    else if (p === 4) state.underline = true;
+    else if (p === 7) state.reverse = true;
+    else if (p === 22) { state.bold = false; state.dim = false; }
+    else if (p === 23) state.italic = false;
+    else if (p === 24) state.underline = false;
+    else if (p === 27) state.reverse = false;
+    else if (p >= 30 && p <= 37) state.fg = BASE_COLORS[p - 30 + (state.bold ? 8 : 0)];
+    else if (p === 38 && params[i + 1] === 5) { state.fg = xterm256(params[i + 2] ?? 0); i += 2; }
+    else if (p === 38 && params[i + 1] === 2) { state.fg = `rgb(${params[i + 2] ?? 0},${params[i + 3] ?? 0},${params[i + 4] ?? 0})`; i += 4; }
+    else if (p === 39) state.fg = null;
+    else if (p >= 40 && p <= 47) state.bg = BASE_COLORS[p - 40];
+    else if (p === 48 && params[i + 1] === 5) { state.bg = xterm256(params[i + 2] ?? 0); i += 2; }
+    else if (p === 48 && params[i + 1] === 2) { state.bg = `rgb(${params[i + 2] ?? 0},${params[i + 3] ?? 0},${params[i + 4] ?? 0})`; i += 4; }
+    else if (p === 49) state.bg = null;
+    else if (p >= 90 && p <= 97) state.fg = BASE_COLORS[p - 90 + 8];
+    else if (p >= 100 && p <= 107) state.bg = BASE_COLORS[p - 100 + 8];
+  }
+}
+
+/** Converts capture-pane -e output (text + SGR escapes only) into styled HTML. */
+export function ansiToHtml(raw: string): string {
+  // capture-pane -e emits SGR only, but strip any other stray escapes defensively.
+  const cleaned = raw
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b\[[0-9;?]*[A-LN-Za-ln-z]/g, '');
+  const state: SgrState = { bold: false, dim: false, italic: false, underline: false, reverse: false, fg: null, bg: null };
+  let html = '';
+  let last = 0;
+  const sgr = /\x1b\[([0-9;]*)m/g;
+  const emit = (text: string) => {
+    if (!text) return;
+    const style = styleFor(state);
+    html += style ? `<span style="${style}">${escapeHtml(text)}</span>` : escapeHtml(text);
+  };
+  for (let match = sgr.exec(cleaned); match; match = sgr.exec(cleaned)) {
+    emit(cleaned.slice(last, match.index));
+    applySgr(state, match[1].split(';').filter(Boolean).map(Number));
+    last = match.index + match[0].length;
+  }
+  emit(cleaned.slice(last));
+  return html;
+}
+
+// ------------------------------------------------------------------ mirror lifecycle
+
+let mirrorTimer: ReturnType<typeof setInterval> | null = null;
+let lastFrame = '';
+
+async function installMirrorChrome(page: Page): Promise<void> {
+  await page.evaluate(({ cols }) => {
+    if (document.getElementById('demo-terminal')) return;
+    document.body.style.margin = '0';
+    document.body.style.background = '#0b0e13';
+    const root = document.createElement('div');
+    root.id = 'demo-terminal';
+    Object.assign(root.style, {
+      display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden',
+      background: '#101418'
+    } satisfies Partial<CSSStyleDeclaration>);
+
+    const bar = document.createElement('div');
+    Object.assign(bar.style, {
+      display: 'flex', alignItems: 'center', gap: '8px', padding: '0 18px', height: '44px',
+      background: '#1a2029', flex: '0 0 auto',
+      font: '500 15px/1 -apple-system, "Segoe UI", system-ui, sans-serif', color: '#768390'
+    } satisfies Partial<CSSStyleDeclaration>);
+    for (const color of ['#f47067', '#c69026', '#57ab5a']) {
+      const light = document.createElement('span');
+      Object.assign(light.style, {
+        width: '13px', height: '13px', borderRadius: '50%', background: color, flex: '0 0 auto'
+      } satisfies Partial<CSSStyleDeclaration>);
+      bar.appendChild(light);
+    }
+    const title = document.createElement('span');
+    title.textContent = `bash — ${cols} cols`;
+    title.style.marginLeft = '12px';
+    bar.appendChild(title);
+    root.appendChild(bar);
+
+    const wrapper = document.createElement('div');
+    Object.assign(wrapper.style, {
+      position: 'relative', flex: '1 1 auto', padding: '20px 28px', overflow: 'hidden'
+    } satisfies Partial<CSSStyleDeclaration>);
+    const content = document.createElement('pre');
+    content.id = 'demo-terminal-content';
+    Object.assign(content.style, {
+      margin: '0',
+      font: '400 20px/27px "SF Mono", ui-monospace, Menlo, Consolas, monospace',
+      color: '#e6edf3', whiteSpace: 'pre', position: 'relative'
+    } satisfies Partial<CSSStyleDeclaration>);
+    const cursor = document.createElement('div');
+    cursor.id = 'demo-terminal-cursor';
+    Object.assign(cursor.style, {
+      position: 'absolute', width: '1ch', height: '27px',
+      background: 'rgba(230, 237, 243, 0.45)', borderRadius: '2px',
+      font: '400 20px/27px "SF Mono", ui-monospace, Menlo, Consolas, monospace',
+      pointerEvents: 'none', transition: 'left 60ms linear, top 60ms linear'
+    } satisfies Partial<CSSStyleDeclaration>);
+    wrapper.appendChild(content);
+    wrapper.appendChild(cursor);
+    root.appendChild(wrapper);
+    document.body.appendChild(root);
+  }, { cols: TERMINAL_COLS });
+}
+
+/**
+ * Navigates the recorded page to the terminal mirror (installing it if needed) and starts the
+ * capture-pane poll. Idempotent — safe to call again in a later act on the same page.
+ */
+export async function showTerminalMirror(page: Page): Promise<void> {
+  if (!page.url().startsWith('about:blank')) {
+    await page.goto('about:blank');
+  }
+  await installMirrorChrome(page);
+  lastFrame = '';
+  if (mirrorTimer) return;
+  let busy = false;
+  mirrorTimer = setInterval(() => {
+    if (busy) return;
+    busy = true;
+    void (async () => {
+      try {
+        const raw = captureTerminal();
+        const cursor = cursorPosition();
+        const frameKey = `${raw}@${cursor.x},${cursor.y}`;
+        if (frameKey !== lastFrame) {
+          lastFrame = frameKey;
+          const html = ansiToHtml(raw.replace(/\n$/, ''));
+          await page.evaluate(({ html, cursor }) => {
+            const content = document.getElementById('demo-terminal-content');
+            const cursorEl = document.getElementById('demo-terminal-cursor');
+            if (!content || !cursorEl) return;
+            content.innerHTML = html;
+            cursorEl.style.display = cursor.visible ? 'block' : 'none';
+            cursorEl.style.left = `calc(28px + ${cursor.x}ch)`;
+            cursorEl.style.top = `${20 + cursor.y * 27}px`;
+          }, { html, cursor });
+        }
+      } catch {
+        // Page navigating or capture hiccup — the next tick will catch up.
+      }
+      busy = false;
+    })();
+  }, 300);
+}
+
+/** Stops the mirror poll — call when the recording is done with the terminal for good. */
+export function stopTerminalMirror(): void {
+  if (mirrorTimer) {
+    clearInterval(mirrorTimer);
+    mirrorTimer = null;
+  }
+}


### PR DESCRIPTION
## Summary
- **Restores vertical scrolling in the CMS Workflow workspace editor.** The routable workspace mounts the editor into a clipped, non-scrolling backoffice region; any workflow taller than the viewport was cut off with no scrollbar. The old Prism-tab wrapper's scroll fix never carried over to the workspace route. The workspace element is now the scroll container, with the editor forced to natural content height. Verified live.
- **Reworks the demo recording's terminal as a tmux capture-pane DOM mirror** (replacing ttyd/xterm in the recorded browser), fixing the wrong-size terminal, the grey unpainted band, and the multi-minute visual freezes in the previous video. Plus four take-reliability fixes found getting the first clean recording through: tmux send-keys silently swallowing `;` (escaped as `\;`), pinning the spawned agent's model, MCP port discovery now requiring an authenticated initialize with a client-credentials token, and fail-fast MCP connectivity guards before the agent launches.

## Test plan
- [x] Scroll fix verified live against the running stack (scroll container present, content reachable, clamping correct)
- [x] Full 7/7-passing real-take recording produced with the new terminal mirror; frames verified at every act (terminal legible full-screen, no freezes, agent TUI mirrored correctly, visitor journey complete)
- [x] `npx tsc --noEmit` clean; `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFkBGMUmY8gxspjrPdFB4Q