### PR TITLE
feat: seed licence-transfer reference workflow + fix upload crash

### DIFF
--- a/src/UmbracoPrism.TestSite/DemoMobileNavSeeder.cs
+++ b/src/UmbracoPrism.TestSite/DemoMobileNavSeeder.cs
@@ -42,6 +42,7 @@ public class DemoMobileNavSeeder(
     private static readonly Guid WebGetInTouchElementKey = new("d7e8f9a0-b1c2-4456-abcd-678901234567");
     private static readonly Guid WebWorkflowsElementKey = new("e8f9a0b1-c2d3-4567-bcde-789012345678");
     private static readonly Guid WebJugglingLicenceElementKey = new("f9a0b1c2-d3e4-4678-cdef-890123456789");
+    private static readonly Guid WebLicenceTransferElementKey = new("0a1b2c3d-4e5f-4789-def0-901234567890");
 
     // Must match MobileNavSchemaSetup.MobileNavItemTypeKey.
     private static readonly Guid MobileNavItemTypeKey = new("a9f4b2c1-3d5e-6f70-8912-34abc5678def");
@@ -107,7 +108,7 @@ public class DemoMobileNavSeeder(
         var needsWebUpdate = settings.HasProperty("webNavLinks") && NeedsBlockListSeed(
             settings.GetValue<string>("webNavLinks"),
             TestSiteSeedContract.HomePageUrl, TestSiteSeedContract.WorkflowPageUrl, TestSiteSeedContract.WorkflowHubUrl,
-            TestSiteSeedContract.JugglingLicencePageUrl);
+            TestSiteSeedContract.JugglingLicencePageUrl, TestSiteSeedContract.LicenceTransferPageUrl);
 
         if (!needsMobileUpdate && !needsWebUpdate)
         {
@@ -124,7 +125,7 @@ public class DemoMobileNavSeeder(
 
         if (needsWebUpdate)
         {
-            logger.LogInformation("DEMO SEEDER: Seeding webNavLinks with Home, Get in Touch, My Workflows, and Apply for a juggling licence items.");
+            logger.LogInformation("DEMO SEEDER: Seeding webNavLinks with Home, Get in Touch, My Workflows, Apply for a juggling licence, and Transfer your licence items.");
             var webBlockListJson = BuildWebNavBlockListJson();
             settings.SetValue("webNavLinks", webBlockListJson);
         }
@@ -339,14 +340,14 @@ public class DemoMobileNavSeeder(
 
     /// <summary>
     /// Builds the desktop nav's Block List JSON — same shape and element type as
-    /// <see cref="BuildBlockListJson"/>, but its own four items (Home, Get in Touch, My
-    /// Workflows, Apply for a juggling licence — genuinely different content from the mobile
-    /// bar's Home/Dashboard/Workflows) and no icons, matching how the desktop header nav has
-    /// always rendered as plain text links. The juggling licence link is the only route into
-    /// Prism's CMS Workflow demo — unlike the MockBusinessApp-hosted GDS demos (reached by
-    /// direct URL, documented for developers testing the toolkit), CMS Workflow's entire point
-    /// is a native, discoverable public journey, so it earns a permanent nav entry the others
-    /// don't.
+    /// <see cref="BuildBlockListJson"/>, but its own five items (Home, Get in Touch, My
+    /// Workflows, Apply for a juggling licence, Transfer your licence — genuinely different
+    /// content from the mobile bar's Home/Dashboard/Workflows) and no icons, matching how the
+    /// desktop header nav has always rendered as plain text links. The two juggling-licence
+    /// links are the only route into Prism's CMS Workflow demos — unlike the
+    /// MockBusinessApp-hosted GDS demos (reached by direct URL, documented for developers
+    /// testing the toolkit), CMS Workflow's entire point is a native, discoverable public
+    /// journey, so each earns a permanent nav entry the others don't.
     /// </summary>
     private static string BuildWebNavBlockListJson()
     {
@@ -354,6 +355,7 @@ public class DemoMobileNavSeeder(
         var getInTouchKey = WebGetInTouchElementKey.ToString();
         var workflowsKey = WebWorkflowsElementKey.ToString();
         var jugglingLicenceKey = WebJugglingLicenceElementKey.ToString();
+        var licenceTransferKey = WebLicenceTransferElementKey.ToString();
 
         var root = new JsonObject
         {
@@ -363,21 +365,24 @@ public class DemoMobileNavSeeder(
                     new JsonObject { ["contentKey"] = homeKey },
                     new JsonObject { ["contentKey"] = getInTouchKey },
                     new JsonObject { ["contentKey"] = workflowsKey },
-                    new JsonObject { ["contentKey"] = jugglingLicenceKey }
+                    new JsonObject { ["contentKey"] = jugglingLicenceKey },
+                    new JsonObject { ["contentKey"] = licenceTransferKey }
                 )
             },
             ["contentData"] = new JsonArray(
                 BuildBlockItem(homeKey, "Home", TestSiteSeedContract.HomePageUrl, mediaKey: null),
                 BuildBlockItem(getInTouchKey, "Get in Touch", TestSiteSeedContract.WorkflowPageUrl, mediaKey: null),
                 BuildBlockItem(workflowsKey, "My Workflows", TestSiteSeedContract.WorkflowHubUrl, mediaKey: null),
-                BuildBlockItem(jugglingLicenceKey, TestSiteSeedContract.JugglingLicencePageName, TestSiteSeedContract.JugglingLicencePageUrl, mediaKey: null)
+                BuildBlockItem(jugglingLicenceKey, TestSiteSeedContract.JugglingLicencePageName, TestSiteSeedContract.JugglingLicencePageUrl, mediaKey: null),
+                BuildBlockItem(licenceTransferKey, TestSiteSeedContract.LicenceTransferNavLabel, TestSiteSeedContract.LicenceTransferPageUrl, mediaKey: null)
             ),
             ["settingsData"] = new JsonArray(),
             ["expose"] = new JsonArray(
                 new JsonObject { ["contentKey"] = homeKey, ["culture"] = null, ["segment"] = null },
                 new JsonObject { ["contentKey"] = getInTouchKey, ["culture"] = null, ["segment"] = null },
                 new JsonObject { ["contentKey"] = workflowsKey, ["culture"] = null, ["segment"] = null },
-                new JsonObject { ["contentKey"] = jugglingLicenceKey, ["culture"] = null, ["segment"] = null }
+                new JsonObject { ["contentKey"] = jugglingLicenceKey, ["culture"] = null, ["segment"] = null },
+                new JsonObject { ["contentKey"] = licenceTransferKey, ["culture"] = null, ["segment"] = null }
             )
         };
 

--- a/src/UmbracoPrism.TestSite/JugglingLicenceCmsWorkflowSeeder.cs
+++ b/src/UmbracoPrism.TestSite/JugglingLicenceCmsWorkflowSeeder.cs
@@ -108,7 +108,11 @@ public class JugglingLicenceCmsWorkflowSeeder(
             return;
         }
 
-        var existing = TestSiteSeedContract.FindContentByAlias(contentService, TestSiteSeedContract.CmsWorkflowPageAlias);
+        // Filtered by workflowKey, not just alias — a second cmsWorkflowPage instance now exists
+        // (transfer-a-juggling-licence's seeded reference), and a bare alias match would find
+        // whichever one happens to be first in the tree and wrongly skip creating this one.
+        var existing = TestSiteSeedContract.FindCmsWorkflowPageByKey(
+            contentService, TestSiteSeedContract.JugglingLicenceWorkflowKey);
         if (existing != null)
         {
             return;

--- a/src/UmbracoPrism.TestSite/LicenceTransferCmsWorkflowSeeder.cs
+++ b/src/UmbracoPrism.TestSite/LicenceTransferCmsWorkflowSeeder.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using UmbracoPrism.Shared.Models.Workflow;
+using UmbracoPrism.WorkflowRuntime.Abstractions;
+
+namespace UmbracoPrism.TestSite;
+
+/// <summary>
+/// Seeds "Transfer a Professional Juggling Licence" — the same definition
+/// <c>tests/demo/licence-transfer-demo.spec.ts</c> has an AI agent design and save live over MCP,
+/// captured afterwards as a "here's one we made earlier" reference so it survives a runtime wipe
+/// without needing a real agent run. Mirrors <see cref="JugglingLicenceCmsWorkflowSeeder"/>
+/// exactly, including the same reasoning for why <see cref="IWorkflowSourceStore"/> (not a raw
+/// DB insert) is the correct save path.
+/// </summary>
+/// <remarks>
+/// A future re-recording of the MCP walkthrough will hit a version conflict saving under this
+/// same key, since the seeder will have already created version 1 — delete the seeded definition
+/// (and its content page/nav entry) via the backoffice first, let the agent create it fresh, then
+/// this seeder will happily recreate the "here's one we made earlier" reference once you're done.
+/// </remarks>
+public class LicenceTransferCmsWorkflowSeeder(
+    IContentService contentService,
+    IContentTypeService contentTypeService,
+    IWorkflowSourceStore workflowSourceStore,
+    IWebHostEnvironment env,
+    IRuntimeState runtimeState,
+    ILogger<LicenceTransferCmsWorkflowSeeder> logger)
+    : INotificationAsyncHandler<UmbracoApplicationStartedNotification>
+{
+    private static readonly JsonSerializerOptions ReadOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        AllowOutOfOrderMetadataProperties = true
+    };
+
+    public async Task HandleAsync(UmbracoApplicationStartedNotification notification, CancellationToken cancellationToken)
+    {
+        if (runtimeState.Level < RuntimeLevel.Run) return;
+        if (!env.IsDevelopment()) return;
+
+        try
+        {
+            await EnsureDefinitionSeededAsync(cancellationToken);
+            EnsureContentPageUnderHome();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "LICENCE TRANSFER SEEDER: Unexpected error; skipping");
+        }
+    }
+
+    private async Task EnsureDefinitionSeededAsync(CancellationToken cancellationToken)
+    {
+        var existing = await workflowSourceStore.LoadAsync(TestSiteSeedContract.JugglingLicenceTransferWorkflowKey, cancellationToken);
+        if (existing is not null)
+        {
+            logger.LogDebug("LICENCE TRANSFER SEEDER: Definition already present; leaving the existing (possibly edited) row untouched");
+            return;
+        }
+
+        var path = Path.Combine(env.ContentRootPath, "cms-workflow-seeds", "transfer-a-juggling-licence.json");
+        if (!File.Exists(path))
+        {
+            logger.LogWarning("LICENCE TRANSFER SEEDER: Seed file not found at {Path}; skipping", path);
+            return;
+        }
+
+        var json = await File.ReadAllTextAsync(path, cancellationToken);
+        var workflow = JsonSerializer.Deserialize<WorkflowDefinitionFile>(json, ReadOptions);
+        if (workflow is null)
+        {
+            logger.LogWarning("LICENCE TRANSFER SEEDER: Seed file failed to deserialize; skipping");
+            return;
+        }
+
+        var result = await workflowSourceStore.SaveAsync(workflow, expectedVersion: 0, cancellationToken);
+        if (!result.Saved)
+        {
+            logger.LogWarning("LICENCE TRANSFER SEEDER: Save reported a conflict (unexpected for a fresh seed); skipping");
+            return;
+        }
+
+        logger.LogInformation("LICENCE TRANSFER SEEDER: Definition seeded and pushed to the live engine");
+    }
+
+    private void EnsureContentPageUnderHome()
+    {
+        var homePage = TestSiteSeedContract.FindContentByAlias(contentService, TestSiteSeedContract.HomePageAlias);
+        if (homePage == null)
+        {
+            logger.LogDebug("LICENCE TRANSFER SEEDER: homePage not found; skipping content seed");
+            return;
+        }
+
+        var contentType = contentTypeService.Get(TestSiteSeedContract.CmsWorkflowPageAlias);
+        if (contentType == null)
+        {
+            logger.LogDebug("LICENCE TRANSFER SEEDER: cmsWorkflowPage doc type not found; skipping (run again after the content-type seeder)");
+            return;
+        }
+
+        var existing = TestSiteSeedContract.FindCmsWorkflowPageByKey(
+            contentService, TestSiteSeedContract.JugglingLicenceTransferWorkflowKey);
+        if (existing != null)
+        {
+            return;
+        }
+
+        logger.LogInformation("LICENCE TRANSFER SEEDER: Creating seeded CMS workflow page");
+
+        var page = contentService.Create(
+            TestSiteSeedContract.LicenceTransferPageName, homePage.Id, TestSiteSeedContract.CmsWorkflowPageAlias);
+        page.SetValue("workflowKey", TestSiteSeedContract.JugglingLicenceTransferWorkflowKey);
+
+        var saveResult = contentService.Save(page);
+        if (!saveResult.Success)
+        {
+            logger.LogWarning("LICENCE TRANSFER SEEDER: Save failed — {Reason}", saveResult.Result);
+            return;
+        }
+
+        var publishResult = contentService.Publish(page, Array.Empty<string>());
+        if (!publishResult.Success)
+        {
+            logger.LogWarning("LICENCE TRANSFER SEEDER: Publish failed — {Reason}", publishResult.Result);
+        }
+    }
+}

--- a/src/UmbracoPrism.TestSite/Program.cs
+++ b/src/UmbracoPrism.TestSite/Program.cs
@@ -3,6 +3,16 @@ using UmbracoPrism.TestSite;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+// A real multi-file upload against the file-upload component's per-field default of 10MB (five
+// fields on the licence-transfer demo, some with a larger explicit MaxSizeBytes) crashed with an
+// unhandled BadHttpRequestException, not a graceful validation error. The actual limit hit isn't
+// Kestrel's own default — it's Umbraco.Cms.Core.Configuration.Models.RuntimeSettings.MaxRequestLength
+// (default 50MB, appsettings key Umbraco:CMS:Runtime:MaxRequestLength, in KB), which
+// UmbracoRequestMiddleware applies to IHttpMaxRequestBodySizeFeature on every Umbraco-routed
+// request — set there (appsettings.json) to match the value below. This Kestrel-level ceiling is
+// kept too, as a fallback for any endpoint that doesn't go through Umbraco's request pipeline.
+builder.WebHost.ConfigureKestrel(options => options.Limits.MaxRequestBodySize = 100 * 1024 * 1024);
+
 // Local secrets override — gitignored. Place Prism:VaultUri and any other
 // environment-specific secrets here. See src/UmbracoPrism.TestSite/README.md.
 builder.Configuration.AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true);

--- a/src/UmbracoPrism.TestSite/TestSiteComposer.cs
+++ b/src/UmbracoPrism.TestSite/TestSiteComposer.cs
@@ -83,10 +83,16 @@ public class TestSiteComposer : IComposer
         });
         builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, JugglingLicenceCmsWorkflowSeeder>();
 
-        // Guidance articles for the (separately, live-authored) "Transfer a Professional
-        // Juggling Licence" CMS Workflow demo — seeded ahead of time so that build has real
-        // CMS content to link to rather than needing to author it on camera.
+        // Guidance articles for "Transfer a Professional Juggling Licence" — seeded ahead of
+        // time so a live MCP build has real CMS content to link to rather than needing to author
+        // it on camera. Must run before LicenceTransferCmsWorkflowSeeder below only in the sense
+        // that both are idempotent and order-independent; listed here because it's the same demo.
         builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, GuidanceArticleContentTypes>();
         builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, GuidanceArticleSeeder>();
+
+        // The "here's one we made earlier" reference copy of the definition the recording builds
+        // live via MCP — see LicenceTransferCmsWorkflowSeeder's own remarks for what a future
+        // re-recording needs to do first.
+        builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, LicenceTransferCmsWorkflowSeeder>();
     }
 }

--- a/src/UmbracoPrism.TestSite/TestSiteSeedContract.cs
+++ b/src/UmbracoPrism.TestSite/TestSiteSeedContract.cs
@@ -48,9 +48,16 @@ public static class TestSiteSeedContract
     public const string JugglingLicencePageUrl = "/apply-for-a-juggling-licence";
     public const string JugglingLicenceWorkflowKey = "apply-for-a-juggling-licence";
 
-    // Built live via MCP (see tests/demo/licence-transfer-demo.spec.ts), not C#-seeded like the
-    // key above — kept here anyway so both juggling-licence workflow keys live in one place.
+    // Originally built live via MCP (see tests/demo/licence-transfer-demo.spec.ts) — that
+    // recording is the definition's real origin story and the reason it exists, but the result
+    // is good enough to also be C# seeded as a permanent "here's one we made earlier" reference,
+    // the same way JugglingLicenceWorkflowKey is (see LicenceTransferCmsWorkflowSeeder). The
+    // page name/URL/nav label below match exactly what the recording itself creates live, so a
+    // fresh Aspire boot and the recorded video agree on every visible detail.
     public const string JugglingLicenceTransferWorkflowKey = "transfer-a-juggling-licence";
+    public const string LicenceTransferPageName = "Transfer your existing juggling licence";
+    public const string LicenceTransferPageUrl = "/transfer-your-existing-juggling-licence";
+    public const string LicenceTransferNavLabel = "Transfer your licence";
 
     public static IContent? FindContentByAlias(IContentService contentService, string alias)
         => EnumerateContentTree(contentService)
@@ -60,6 +67,18 @@ public static class TestSiteSeedContract
         => EnumerateContentTree(contentService)
                .FirstOrDefault(content =>
                    content.ContentType.Alias == WorkflowPageAlias
+                   && string.Equals(content.GetValue<string>("workflowKey"), workflowKey, StringComparison.OrdinalIgnoreCase));
+
+    // cmsWorkflowPage is a distinct doc type from workflowPage above (Prism's newer,
+    // Umbraco-only-hosted CMS Workflow, not the older business-workflow demos) — and more than
+    // one cmsWorkflowPage instance can now exist (apply-for-a-juggling-licence,
+    // transfer-a-juggling-licence), so a seeder checking "does my page already exist" must
+    // filter by workflowKey, not just by alias (which would match whichever page happens to be
+    // first in the tree and wrongly skip creating the other one).
+    public static IContent? FindCmsWorkflowPageByKey(IContentService contentService, string workflowKey)
+        => EnumerateContentTree(contentService)
+               .FirstOrDefault(content =>
+                   content.ContentType.Alias == CmsWorkflowPageAlias
                    && string.Equals(content.GetValue<string>("workflowKey"), workflowKey, StringComparison.OrdinalIgnoreCase));
 
     public static IPublishedContent? FindPublishedByAlias(IEnumerable<IPublishedContent> roots, string alias)

--- a/src/UmbracoPrism.TestSite/appsettings.json
+++ b/src/UmbracoPrism.TestSite/appsettings.json
@@ -32,6 +32,9 @@
         "ModelsMode": "InMemoryAuto",
         "ModelsNamespace": "Umbraco.Cms.Web.Common.PublishedModels",
         "AcceptUnsafeModelsDirectory": true
+      },
+      "Runtime": {
+        "MaxRequestLength": 102400
       }
     }
   },

--- a/src/UmbracoPrism.TestSite/cms-workflow-seeds/transfer-a-juggling-licence.json
+++ b/src/UmbracoPrism.TestSite/cms-workflow-seeds/transfer-a-juggling-licence.json
@@ -1,0 +1,840 @@
+{
+  "definitionKey": "transfer-a-juggling-licence",
+  "displayName": "Transfer a Professional Juggling Licence",
+  "version": 1,
+  "schemaVersion": "1.0",
+  "description": "Prism CMS Workflow \u2014 GDS-style public journey for a juggler who already holds a professional licence from an overseas juggling authority, transferring it to the National Juggling Authority.",
+  "initialState": "eligibility-professional",
+  "instancePolicy": "single",
+  "calculations": {
+    "fields": {
+      "member": {
+        "source": "service"
+      },
+      "isMember": {
+        "expr": "member.tier <> ''"
+      },
+      "membershipTier": {
+        "expr": "member.tier"
+      }
+    }
+  },
+  "queues": [
+    {
+      "key": "cms-visitor",
+      "displayName": "Site visitor",
+      "description": "The site visitor transferring a professional juggling licence \u2014 anonymous, or a logged-in Prism Member.",
+      "actor": "applicant"
+    }
+  ],
+  "states": [
+    {
+      "stateKey": "eligibility-professional",
+      "displayName": "Have you performed professionally?",
+      "stageType": "Question",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "inset-text",
+          "content": "A licence transfer is only available to jugglers who have previously performed professionally."
+        },
+        {
+          "type": "heading",
+          "level": 2,
+          "content": "Have you previously performed professionally as a juggler?"
+        }
+      ],
+      "routes": [
+        {
+          "id": "eligibility-professional--yes--route-from-eligibility-professional",
+          "target": "route-from-eligibility-professional",
+          "trigger": "yes",
+          "label": "Yes"
+        },
+        {
+          "id": "eligibility-professional--no--route-from-eligibility-professional",
+          "target": "route-from-eligibility-professional",
+          "trigger": "no",
+          "label": "No",
+          "style": "secondary"
+        }
+      ]
+    },
+    {
+      "stateKey": "eligibility-overseas",
+      "displayName": "Where was your licence issued?",
+      "stageType": "Question",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "heading",
+          "level": 2,
+          "content": "Was your existing licence issued by an authority outside the UK?"
+        }
+      ],
+      "routes": [
+        {
+          "id": "eligibility-overseas--yes--route-from-eligibility-overseas",
+          "target": "route-from-eligibility-overseas",
+          "trigger": "yes",
+          "label": "Yes"
+        },
+        {
+          "id": "eligibility-overseas--no--route-from-eligibility-overseas",
+          "target": "route-from-eligibility-overseas",
+          "trigger": "no",
+          "label": "No",
+          "style": "secondary"
+        }
+      ]
+    },
+    {
+      "stateKey": "eligibility-recognised",
+      "displayName": "Is your issuing authority recognised?",
+      "stageType": "Question",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "inset-text",
+          "content": "We can only transfer licences issued by an overseas authority recognised by the International Juggling Accreditation Register (IJAR)."
+        },
+        {
+          "type": "heading",
+          "level": 2,
+          "content": "Is the authority that issued your licence recognised by the International Juggling Accreditation Register (IJAR)?"
+        }
+      ],
+      "routes": [
+        {
+          "id": "eligibility-recognised--yes--route-from-eligibility-recognised",
+          "target": "route-from-eligibility-recognised",
+          "trigger": "yes",
+          "label": "Yes"
+        },
+        {
+          "id": "eligibility-recognised--no--route-from-eligibility-recognised",
+          "target": "route-from-eligibility-recognised",
+          "trigger": "no",
+          "label": "No",
+          "style": "secondary"
+        }
+      ]
+    },
+    {
+      "stateKey": "ineligible-not-professional",
+      "displayName": "You cannot transfer a licence",
+      "stageType": "Outcome",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "panel",
+          "heading": "You're not eligible to transfer a licence"
+        },
+        {
+          "type": "body",
+          "content": "A professional licence transfer is only available to jugglers who have previously performed professionally. Based on your answer, you're not eligible to use this service."
+        },
+        {
+          "type": "body",
+          "content": "If you'd like to juggle recreationally or competitively, you can apply for a new licence instead."
+        }
+      ],
+      "routes": []
+    },
+    {
+      "stateKey": "ineligible-licence-not-overseas",
+      "displayName": "You cannot transfer a licence",
+      "stageType": "Outcome",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "panel",
+          "heading": "You're not eligible to transfer a licence"
+        },
+        {
+          "type": "body",
+          "content": "This service is only for transferring a licence issued by an authority outside the UK. If your licence was issued in the UK, there's nothing to transfer \u2014 it's already recognised by the National Juggling Authority."
+        }
+      ],
+      "routes": []
+    },
+    {
+      "stateKey": "ineligible-authority-not-recognised",
+      "displayName": "You cannot transfer a licence",
+      "stageType": "Outcome",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "panel",
+          "heading": "You're not eligible to transfer a licence"
+        },
+        {
+          "type": "body",
+          "content": "We can only transfer licences issued by an overseas authority recognised by the International Juggling Accreditation Register (IJAR). Because your issuing authority isn't recognised, we can't transfer your licence."
+        },
+        {
+          "type": "body",
+          "content": "Contact the National Juggling Authority if you believe your issuing authority should be recognised."
+        }
+      ],
+      "routes": []
+    },
+    {
+      "stateKey": "guidance",
+      "displayName": "Before you continue",
+      "stageType": "Question",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "guidance-checklist",
+          "items": [
+            {
+              "key": "transfer-rules",
+              "label": "Transfer Rules",
+              "href": "/transfer-rules"
+            },
+            {
+              "key": "international-transfers",
+              "label": "International Transfers",
+              "href": "/international-transfers"
+            },
+            {
+              "key": "supporting-evidence",
+              "label": "Supporting Evidence",
+              "href": "/supporting-evidence"
+            },
+            {
+              "key": "professional-standards",
+              "label": "Professional Standards",
+              "href": "/professional-standards"
+            }
+          ],
+          "fieldKey": "guidance-acknowledgement",
+          "label": "Read the following guidance before you apply",
+          "hint": null,
+          "required": true,
+          "conditionalOn": null,
+          "visibleWhen": null,
+          "default": null,
+          "defaultFrom": null,
+          "changeStateKey": null
+        }
+      ],
+      "routes": [
+        {
+          "id": "guidance--continue--route-from-guidance",
+          "target": "route-from-guidance",
+          "trigger": "continue"
+        }
+      ]
+    },
+    {
+      "stateKey": "licence-details",
+      "displayName": "Your existing licence",
+      "stageType": "Question",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "stat-group",
+          "title": "Your Juggling Society membership",
+          "items": [
+            {
+              "label": "Membership tier",
+              "fieldKey": "membershipTier",
+              "qualifier": null,
+              "emphasis": false
+            }
+          ],
+          "showWhen": "isMember"
+        },
+        {
+          "type": "inset-text",
+          "content": "Because you're signed in as a Juggling Society member, we've pre-selected the professional category below to match your membership tier shown above. If your existing licence is in a different category, choose it instead \u2014 your answer here is what we'll use, whatever your membership says.",
+          "showWhen": "isMember"
+        },
+        {
+          "type": "fieldset",
+          "children": [
+            {
+              "type": "text",
+              "minLength": null,
+              "maxLength": 150,
+              "pattern": null,
+              "prefix": null,
+              "fieldKey": "current-authority",
+              "label": "Name of the authority that issued your current licence",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            },
+            {
+              "type": "text",
+              "minLength": null,
+              "maxLength": 50,
+              "pattern": null,
+              "prefix": null,
+              "fieldKey": "licence-reference",
+              "label": "Licence reference number",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            },
+            {
+              "type": "date",
+              "fieldKey": "issue-date",
+              "label": "Date your licence was issued",
+              "hint": "For example, 12 03 2020",
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            },
+            {
+              "type": "date",
+              "fieldKey": "expiry-date",
+              "label": "Date your licence expires",
+              "hint": "For example, 12 03 2027",
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            },
+            {
+              "type": "radio",
+              "options": [
+                "Recreational",
+                "Competitive",
+                "Professional"
+              ],
+              "conditionalChildren": null,
+              "fieldKey": "professional-category",
+              "label": "What professional category is your existing licence?",
+              "hint": "Choose the option that best matches your existing licence. If we've pre-selected one for you above, you can still choose a different one.",
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": "membershipTier",
+              "changeStateKey": null
+            }
+          ],
+          "legend": "Your existing licence details",
+          "legendSize": null
+        }
+      ],
+      "routes": [
+        {
+          "id": "licence-details--continue--route-from-licence-details",
+          "target": "route-from-licence-details",
+          "trigger": "continue"
+        }
+      ]
+    },
+    {
+      "stateKey": "upload-evidence",
+      "displayName": "Upload your evidence",
+      "stageType": "Question",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "fieldset",
+          "children": [
+            {
+              "type": "file-upload",
+              "acceptedFileTypes": [
+                ".pdf",
+                ".jpg",
+                ".png"
+              ],
+              "maxSizeBytes": null,
+              "fieldKey": "current-licence-upload",
+              "label": "Your current licence",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            },
+            {
+              "type": "file-upload",
+              "acceptedFileTypes": [
+                ".pdf",
+                ".jpg",
+                ".png"
+              ],
+              "maxSizeBytes": null,
+              "fieldKey": "proof-of-identity-upload",
+              "label": "Proof of identity",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            },
+            {
+              "type": "file-upload",
+              "acceptedFileTypes": [
+                ".pdf",
+                ".jpg",
+                ".png"
+              ],
+              "maxSizeBytes": null,
+              "fieldKey": "proof-of-address-upload",
+              "label": "Proof of address",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            },
+            {
+              "type": "file-upload",
+              "acceptedFileTypes": [
+                ".pdf",
+                ".jpg",
+                ".png"
+              ],
+              "maxSizeBytes": null,
+              "fieldKey": "professional-portfolio-upload",
+              "label": "Professional portfolio",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            },
+            {
+              "type": "file-upload",
+              "acceptedFileTypes": [
+                ".mp4",
+                ".mov"
+              ],
+              "maxSizeBytes": null,
+              "fieldKey": "video-evidence-upload",
+              "label": "Video evidence (optional)",
+              "hint": null,
+              "required": false,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            }
+          ],
+          "legend": "Supporting documents",
+          "legendSize": null
+        }
+      ],
+      "routes": [
+        {
+          "id": "upload-evidence--continue--route-from-upload-evidence",
+          "target": "route-from-upload-evidence",
+          "trigger": "continue"
+        }
+      ]
+    },
+    {
+      "stateKey": "check-answers",
+      "displayName": "Check your answers",
+      "stageType": "CheckAnswers",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "summary-list",
+          "children": [
+            {
+              "type": "text",
+              "minLength": null,
+              "maxLength": null,
+              "pattern": null,
+              "prefix": null,
+              "fieldKey": "current-authority",
+              "label": "Current issuing authority",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": "licence-details"
+            },
+            {
+              "type": "text",
+              "minLength": null,
+              "maxLength": null,
+              "pattern": null,
+              "prefix": null,
+              "fieldKey": "licence-reference",
+              "label": "Licence reference number",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": "licence-details"
+            },
+            {
+              "type": "date",
+              "fieldKey": "issue-date",
+              "label": "Date licence was issued",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": "licence-details"
+            },
+            {
+              "type": "date",
+              "fieldKey": "expiry-date",
+              "label": "Date licence expires",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": "licence-details"
+            },
+            {
+              "type": "radio",
+              "options": [
+                "Recreational",
+                "Competitive",
+                "Professional"
+              ],
+              "conditionalChildren": null,
+              "fieldKey": "professional-category",
+              "label": "Professional category",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": "licence-details"
+            },
+            {
+              "type": "file-upload",
+              "acceptedFileTypes": null,
+              "maxSizeBytes": null,
+              "fieldKey": "current-licence-upload",
+              "label": "Current licence",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": "upload-evidence"
+            },
+            {
+              "type": "file-upload",
+              "acceptedFileTypes": null,
+              "maxSizeBytes": null,
+              "fieldKey": "proof-of-identity-upload",
+              "label": "Proof of identity",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": "upload-evidence"
+            },
+            {
+              "type": "file-upload",
+              "acceptedFileTypes": null,
+              "maxSizeBytes": null,
+              "fieldKey": "proof-of-address-upload",
+              "label": "Proof of address",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": "upload-evidence"
+            },
+            {
+              "type": "file-upload",
+              "acceptedFileTypes": null,
+              "maxSizeBytes": null,
+              "fieldKey": "professional-portfolio-upload",
+              "label": "Professional portfolio",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": "upload-evidence"
+            },
+            {
+              "type": "file-upload",
+              "acceptedFileTypes": null,
+              "maxSizeBytes": null,
+              "fieldKey": "video-evidence-upload",
+              "label": "Video evidence",
+              "hint": null,
+              "required": false,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": "upload-evidence"
+            }
+          ],
+          "changeStateKey": null,
+          "title": null
+        }
+      ],
+      "routes": [
+        {
+          "id": "check-answers--continue--route-from-check-answers",
+          "target": "route-from-check-answers",
+          "trigger": "continue"
+        }
+      ]
+    },
+    {
+      "stateKey": "declaration",
+      "displayName": "Declaration",
+      "stageType": "Question",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "fieldset",
+          "children": [
+            {
+              "type": "boolean",
+              "fieldKey": "information-accurate-declaration",
+              "label": "I confirm the information I have given is accurate",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            },
+            {
+              "type": "boolean",
+              "fieldKey": "authorise-contact-declaration",
+              "label": "I authorise the National Juggling Authority to contact my current licensing body to verify these details",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            },
+            {
+              "type": "boolean",
+              "fieldKey": "misleading-information-declaration",
+              "label": "I understand that providing misleading information may result in my application being rejected",
+              "hint": null,
+              "required": true,
+              "conditionalOn": null,
+              "visibleWhen": null,
+              "default": null,
+              "defaultFrom": null,
+              "changeStateKey": null
+            }
+          ],
+          "legend": "Before you submit",
+          "legendSize": null
+        }
+      ],
+      "routes": [
+        {
+          "id": "declaration--submit--route-from-declaration",
+          "target": "route-from-declaration",
+          "trigger": "submit"
+        }
+      ]
+    },
+    {
+      "stateKey": "confirmation",
+      "displayName": "Transfer application submitted",
+      "stageType": "Confirmation",
+      "actor": "applicant",
+      "queueKey": "cms-visitor",
+      "components": [
+        {
+          "type": "panel",
+          "heading": "Transfer application submitted"
+        },
+        {
+          "type": "heading",
+          "level": 2,
+          "content": "What happens next"
+        },
+        {
+          "type": "body",
+          "content": "We've sent a confirmation to the email address you gave us."
+        },
+        {
+          "type": "body",
+          "content": "The National Juggling Authority will contact your current licensing body to verify your details, then be in touch about the outcome of your transfer."
+        }
+      ],
+      "routes": []
+    }
+  ],
+  "gateways": [
+    {
+      "key": "route-from-eligibility-professional",
+      "displayName": "Route from professional performance question",
+      "gatewayType": "Split",
+      "queueKey": "cms-visitor",
+      "routes": [
+        {
+          "id": "route-from-eligibility-professional--yes--eligibility-overseas",
+          "target": "eligibility-overseas",
+          "trigger": "yes"
+        },
+        {
+          "id": "route-from-eligibility-professional--no--ineligible-not-professional",
+          "target": "ineligible-not-professional",
+          "trigger": "no"
+        }
+      ]
+    },
+    {
+      "key": "route-from-eligibility-overseas",
+      "displayName": "Route from overseas issue question",
+      "gatewayType": "Split",
+      "queueKey": "cms-visitor",
+      "routes": [
+        {
+          "id": "route-from-eligibility-overseas--yes--eligibility-recognised",
+          "target": "eligibility-recognised",
+          "trigger": "yes"
+        },
+        {
+          "id": "route-from-eligibility-overseas--no--ineligible-licence-not-overseas",
+          "target": "ineligible-licence-not-overseas",
+          "trigger": "no"
+        }
+      ]
+    },
+    {
+      "key": "route-from-eligibility-recognised",
+      "displayName": "Route from authority recognition question",
+      "gatewayType": "Split",
+      "queueKey": "cms-visitor",
+      "routes": [
+        {
+          "id": "route-from-eligibility-recognised--yes--guidance",
+          "target": "guidance",
+          "trigger": "yes"
+        },
+        {
+          "id": "route-from-eligibility-recognised--no--ineligible-authority-not-recognised",
+          "target": "ineligible-authority-not-recognised",
+          "trigger": "no"
+        }
+      ]
+    },
+    {
+      "key": "route-from-guidance",
+      "displayName": "Continue to licence details",
+      "gatewayType": "Split",
+      "queueKey": "cms-visitor",
+      "routes": [
+        {
+          "id": "route-from-guidance--continue--licence-details",
+          "target": "licence-details",
+          "trigger": "continue"
+        }
+      ]
+    },
+    {
+      "key": "route-from-licence-details",
+      "displayName": "Continue to upload evidence",
+      "gatewayType": "Split",
+      "queueKey": "cms-visitor",
+      "routes": [
+        {
+          "id": "route-from-licence-details--continue--upload-evidence",
+          "target": "upload-evidence",
+          "trigger": "continue"
+        }
+      ]
+    },
+    {
+      "key": "route-from-upload-evidence",
+      "displayName": "Continue to check your answers",
+      "gatewayType": "Split",
+      "queueKey": "cms-visitor",
+      "routes": [
+        {
+          "id": "route-from-upload-evidence--continue--check-answers",
+          "target": "check-answers",
+          "trigger": "continue"
+        }
+      ]
+    },
+    {
+      "key": "route-from-check-answers",
+      "displayName": "Continue to declaration",
+      "gatewayType": "Split",
+      "queueKey": "cms-visitor",
+      "routes": [
+        {
+          "id": "route-from-check-answers--continue--declaration",
+          "target": "declaration",
+          "trigger": "continue"
+        }
+      ]
+    },
+    {
+      "key": "route-from-declaration",
+      "displayName": "Submit transfer application",
+      "gatewayType": "Split",
+      "queueKey": "cms-visitor",
+      "routes": [
+        {
+          "id": "route-from-declaration--submit--confirmation",
+          "target": "confirmation",
+          "trigger": "submit"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Seeds "Transfer a Professional Juggling Licence" (the definition the recording builds live via MCP) as a permanent "here's one we made earlier" reference, mirroring how `apply-for-a-juggling-licence` is already seeded — survives a runtime wipe, browsable without a real agent run.
- Fixes a latent idempotency bug in both CMS Workflow content-page seeders (alias-only lookup would match whichever `cmsWorkflowPage` happened to be first in the tree).
- Fixes an unhandled 500 (`BadHttpRequestException`) on a real-sized multi-file upload — root cause was Umbraco's own `RuntimeSettings.MaxRequestLength` (50MB default), not Kestrel's limit as first suspected; confirmed live via direct testing that a Kestrel-only fix silently had no effect.

## Test plan
- [x] Full clean Aspire boot (`PRISM_TESTSITE_RESET_RUNTIME=true`) — both `apply-for-a-juggling-licence` and `transfer-your-existing-juggling-licence` pages and nav links present from scratch
- [x] `dotnet test src/UmbracoPrism.Core.Tests/` — 989 passed
- [x] `npx tsc --noEmit` clean
- [x] Live upload verification: a file over the 10MB per-field limit now shows a real GDS validation error (not a crash); a correctly-sized 5-file upload completes through to Check Your Answers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFkBGMUmY8gxspjrPdFB4Q