### PR TITLE
feat: GDS-quality streaming file upload with progress bar

### DIFF
--- a/src/UmbracoPrism.Client/src/file-upload/prism-file-upload.ts
+++ b/src/UmbracoPrism.Client/src/file-upload/prism-file-upload.ts
@@ -1,0 +1,226 @@
+// ⚠️ MOBILE BOUNDARY: No @umbraco-cms imports allowed in this directory.
+//
+// Generic progressive enhancement for any file-upload field. Independent of prism-live-form.ts
+// (which only boots when a stage declares a calculations block) — a stage can have file-upload
+// fields with no calculations at all, so this boots on its own, gated purely on whether
+// [data-prism-file-upload] exists on the page (see PrismWorkflowViewModel.HasFileUploadField for
+// the server-side half of that gate).
+//
+// On choosing a file, uploads it immediately via XMLHttpRequest (not fetch — upload.onprogress
+// is what makes a real, accessible progress bar possible) to CmsWorkflowFileUploadController,
+// ahead of the stage's own Continue button. A hidden input then carries the server-issued token
+// as the field's actual submitted value; PrismWorkflowPageController.HandlePost resolves it back
+// to the already-saved file. It contains no domain knowledge — the workflow JSON decides which
+// fields exist; this runtime only wires up whatever it finds.
+
+const PROGRESS_ANNOUNCE_STEP = 10; // percentage points between aria-live progress announcements
+
+interface UploadResult {
+  token: string;
+  fileName: string;
+  sizeBytes: number;
+  downloadUrl: string;
+}
+
+function injectStylesOnce(): void {
+  const id = 'prism-file-upload-styles';
+  if (document.getElementById(id)) return;
+
+  const style = document.createElement('style');
+  style.id = id;
+  // No official GOV.UK Design System pattern for an upload progress bar — kept deliberately
+  // close to govuk-frontend's own visual language (its grey/blue palette) rather than
+  // introducing a new one.
+  style.textContent = `
+    .prism-file-upload-progress-track {
+      background: #b1b4b6;
+      border-radius: 5px;
+      height: 10px;
+      overflow: hidden;
+      margin: 10px 0;
+      max-width: 400px;
+    }
+    .prism-file-upload-progress-fill {
+      background: #1d70b8;
+      height: 100%;
+      width: 0%;
+      transition: width 120ms linear;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function getAntiforgeryToken(): string {
+  const input = document.querySelector<HTMLInputElement>('input[name="__RequestVerificationToken"]');
+  return input?.value ?? '';
+}
+
+function formatMaxSize(bytes: number): string {
+  return bytes >= 1024 * 1024 ? `${(bytes / (1024 * 1024)).toFixed(0)}MB` : `${Math.ceil(bytes / 1024)}KB`;
+}
+
+function fieldOf(host: HTMLElement, hook: string): HTMLElement | null {
+  return host.querySelector<HTMLElement>(`[data-prism-file-upload-${hook}]`);
+}
+
+function setError(host: HTMLElement, message: string | null): void {
+  const errorEl = fieldOf(host, 'error');
+  if (!errorEl) return;
+  errorEl.textContent = message ?? '';
+  errorEl.hidden = !message;
+}
+
+function setProgress(host: HTMLElement, percent: number, lastAnnounced: { value: number }): void {
+  const fill = fieldOf(host, 'progress-fill');
+  const bar = fieldOf(host, 'progress-bar');
+  const announce = fieldOf(host, 'progress-announce');
+  if (fill) fill.style.width = `${percent}%`;
+  bar?.setAttribute('aria-valuenow', String(percent));
+  if (announce && percent - lastAnnounced.value >= PROGRESS_ANNOUNCE_STEP) {
+    lastAnnounced.value = percent;
+    announce.textContent = `Uploading, ${percent}% complete`;
+  }
+}
+
+function showUploading(host: HTMLElement): void {
+  const progressEl = fieldOf(host, 'progress');
+  const inputEl = fieldOf(host, 'input') as HTMLInputElement | null;
+  const uploadedEl = fieldOf(host, 'uploaded');
+  if (progressEl) progressEl.hidden = false;
+  if (inputEl) inputEl.hidden = true;
+  if (uploadedEl) uploadedEl.hidden = true;
+  setProgress(host, 0, { value: -PROGRESS_ANNOUNCE_STEP });
+}
+
+function showUploaded(host: HTMLElement, result: UploadResult): void {
+  const uploadedEl = fieldOf(host, 'uploaded');
+  const filenameEl = fieldOf(host, 'filename');
+  const viewLink = fieldOf(host, 'view-link') as HTMLAnchorElement | null;
+  const inputEl = fieldOf(host, 'input') as HTMLInputElement | null;
+  const tokenEl = fieldOf(host, 'token') as HTMLInputElement | null;
+  const progressEl = fieldOf(host, 'progress');
+
+  if (filenameEl) filenameEl.textContent = result.fileName;
+  if (viewLink) {
+    viewLink.href = result.downloadUrl;
+    viewLink.hidden = false;
+  }
+  if (uploadedEl) uploadedEl.hidden = false;
+  if (inputEl) {
+    // Disabled, not just hidden — an unselected <input type="file"> still submits an
+    // empty-but-present part under this same "fields[...]" name, which would silently
+    // overwrite this real reference with a zero-byte one on the eventual stage submission.
+    inputEl.hidden = true;
+    inputEl.disabled = true;
+  }
+  if (progressEl) progressEl.hidden = true;
+  if (tokenEl) {
+    tokenEl.value = result.token;
+    tokenEl.disabled = false;
+  }
+  setError(host, null);
+}
+
+/** Back to "nothing chosen yet" — a fresh field, a failed upload, or "Choose a different file". */
+function showEmpty(host: HTMLElement): void {
+  const uploadedEl = fieldOf(host, 'uploaded');
+  const inputEl = fieldOf(host, 'input') as HTMLInputElement | null;
+  const tokenEl = fieldOf(host, 'token') as HTMLInputElement | null;
+  const progressEl = fieldOf(host, 'progress');
+
+  if (uploadedEl) uploadedEl.hidden = true;
+  if (inputEl) {
+    inputEl.hidden = false;
+    inputEl.disabled = false;
+    inputEl.value = '';
+  }
+  if (progressEl) progressEl.hidden = true;
+  if (tokenEl) {
+    tokenEl.value = '';
+    tokenEl.disabled = true;
+  }
+}
+
+function uploadFile(host: HTMLElement, file: File): void {
+  const uploadUrl = host.dataset.prismUploadUrl ?? '';
+  const nonce = host.dataset.prismNonce ?? '';
+  const maxSize = Number(host.dataset.prismMaxSize ?? '0');
+  const accept = (host.dataset.prismAccept ?? '').split(',').map(s => s.trim()).filter(Boolean);
+  const label = host.dataset.prismLabel || 'This file';
+
+  if (maxSize > 0 && file.size > maxSize) {
+    setError(host, `${label} must be smaller than ${formatMaxSize(maxSize)}.`);
+    showEmpty(host);
+    return;
+  }
+  if (accept.length > 0) {
+    const dot = file.name.lastIndexOf('.');
+    const extension = dot >= 0 ? file.name.slice(dot) : '';
+    if (!accept.some(a => a.toLowerCase() === extension.toLowerCase())) {
+      setError(host, `${label} must be one of: ${accept.join(', ')}.`);
+      showEmpty(host);
+      return;
+    }
+  }
+
+  setError(host, null);
+  showUploading(host);
+
+  const formData = new FormData();
+  formData.append('file', file, file.name);
+  formData.append('nonce', nonce);
+  formData.append('__RequestVerificationToken', getAntiforgeryToken());
+
+  const lastAnnounced = { value: -PROGRESS_ANNOUNCE_STEP };
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', uploadUrl, true);
+  xhr.upload.addEventListener('progress', event => {
+    if (!event.lengthComputable) return;
+    setProgress(host, Math.round((event.loaded / event.total) * 100), lastAnnounced);
+  });
+  xhr.addEventListener('load', () => {
+    if (xhr.status >= 200 && xhr.status < 300) {
+      try {
+        showUploaded(host, JSON.parse(xhr.responseText) as UploadResult);
+        return;
+      } catch {
+        // fall through to the generic error below
+      }
+    }
+    setError(host, xhr.responseText || 'Something went wrong uploading this file. Try again.');
+    showEmpty(host);
+  });
+  xhr.addEventListener('error', () => {
+    setError(host, 'Something went wrong uploading this file. Try again.');
+    showEmpty(host);
+  });
+  xhr.send(formData);
+}
+
+function bootField(host: HTMLElement): void {
+  const inputEl = fieldOf(host, 'input') as HTMLInputElement | null;
+  const changeButton = fieldOf(host, 'change');
+
+  inputEl?.addEventListener('change', () => {
+    const file = inputEl.files?.[0];
+    if (file) uploadFile(host, file);
+  });
+
+  changeButton?.addEventListener('click', () => {
+    showEmpty(host);
+    inputEl?.focus();
+  });
+}
+
+function boot(): void {
+  const fields = document.querySelectorAll<HTMLElement>('[data-prism-file-upload]');
+  if (fields.length === 0) return;
+  injectStylesOnce();
+  fields.forEach(bootField);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', boot);
+} else {
+  boot();
+}

--- a/src/UmbracoPrism.Client/vite.config.ts
+++ b/src/UmbracoPrism.Client/vite.config.ts
@@ -28,6 +28,11 @@ export default defineConfig({
         // Generic live-form runtime: re-evaluates a workflow's declarative
         // calculations client-side and updates bound components in place
         'prism-live-form': 'src/live-form/prism-live-form.ts',
+        // Generic file-upload runtime: uploads a chosen file immediately with a real progress
+        // bar, independent of prism-live-form (a stage can have file-upload fields with no
+        // calculations block at all) — see PrismWorkflowViewModel.HasFileUploadField for the
+        // matching server-side gate on whether this script is even included.
+        'prism-file-upload': 'src/file-upload/prism-file-upload.ts',
       },
       output: {
         format: 'es',

--- a/src/UmbracoPrism.Core.Tests/Services/Workflow/UploadTokenServiceTests.cs
+++ b/src/UmbracoPrism.Core.Tests/Services/Workflow/UploadTokenServiceTests.cs
@@ -1,0 +1,167 @@
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
+using Moq;
+using UmbracoPrism.Core.Configuration;
+using UmbracoPrism.Core.Services;
+using UmbracoPrism.Shared.Models.Workflow;
+
+namespace UmbracoPrism.Core.Tests.Services.Workflow;
+
+public class UploadTokenServiceTests
+{
+    private static UploadTokenService BuildService(
+        IDistributedCache? cache = null,
+        PrismWorkflowOptions? options = null)
+    {
+        cache ??= new Mock<IDistributedCache>().Object;
+        options ??= new PrismWorkflowOptions();
+        return new UploadTokenService(cache, Options.Create(options));
+    }
+
+    private static WorkflowFileReference SampleReference() => new()
+    {
+        StorageKey = "abc123.pdf",
+        OriginalFileName = "evidence.pdf",
+        ContentType = "application/pdf",
+        SizeBytes = 1024
+    };
+
+    // ------------------------------------------------------------------ CreateAsync
+
+    [Fact]
+    public async Task CreateAsync_ReturnsNonEmptyString()
+    {
+        var service = BuildService();
+
+        var token = await service.CreateAsync("instance-1", "current-licence-upload", SampleReference());
+
+        token.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task CreateAsync_TokenIs32HexChars()
+    {
+        var service = BuildService();
+
+        var token = await service.CreateAsync("instance-1", "current-licence-upload", SampleReference());
+
+        token.Should().MatchRegex("^[0-9a-f]{32}$");
+    }
+
+    [Fact]
+    public async Task CreateAsync_StoresCacheEntryUnderUploadTokenPrefix()
+    {
+        var cacheMock = new Mock<IDistributedCache>();
+        var service = BuildService(cache: cacheMock.Object);
+
+        await service.CreateAsync("instance-1", "current-licence-upload", SampleReference());
+
+        cacheMock.Verify(
+            c => c.SetAsync(
+                It.Is<string>(key => key.StartsWith("prism:workflow:upload-token:")),
+                It.IsAny<byte[]>(),
+                It.IsAny<DistributedCacheEntryOptions>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAsync_UsesTtlFromOptions()
+    {
+        var cacheMock = new Mock<IDistributedCache>();
+        var options = new PrismWorkflowOptions { NonceExpiry = TimeSpan.FromMinutes(45) };
+        var service = BuildService(cache: cacheMock.Object, options: options);
+
+        await service.CreateAsync("instance-1", "current-licence-upload", SampleReference());
+
+        cacheMock.Verify(
+            c => c.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.Is<DistributedCacheEntryOptions>(opts =>
+                    opts.AbsoluteExpirationRelativeToNow == TimeSpan.FromMinutes(45)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GivenTwoTokens_WhenCreated_ThenDifferentValues()
+    {
+        var service = BuildService();
+
+        var token1 = await service.CreateAsync("instance-1", "field-a", SampleReference());
+        var token2 = await service.CreateAsync("instance-1", "field-a", SampleReference());
+
+        token1.Should().NotBe(token2);
+    }
+
+    // ------------------------------------------------------------------ ResolveAsync
+
+    [Fact]
+    public async Task ResolveAsync_UnknownToken_ReturnsNull()
+    {
+        var cacheMock = new Mock<IDistributedCache>();
+        cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null);
+
+        var service = BuildService(cache: cacheMock.Object);
+
+        var resolved = await service.ResolveAsync("unknown-token");
+
+        resolved.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_CallsCacheWithCorrectKey()
+    {
+        var cacheMock = new Mock<IDistributedCache>();
+        cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null);
+
+        var service = BuildService(cache: cacheMock.Object);
+
+        await service.ResolveAsync("abc123def456abc123def456abc12345");
+
+        cacheMock.Verify(
+            c => c.GetAsync(
+                "prism:workflow:upload-token:abc123def456abc123def456abc12345",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ------------------------------------------------------------------ Round-trip
+
+    [Fact]
+    public async Task GivenCreatedToken_WhenResolved_ThenBindingMatchesInstanceFieldAndReference()
+    {
+        var storedData = (byte[]?)null;
+        var cacheMock = new Mock<IDistributedCache>();
+
+        cacheMock.Setup(c => c.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<DistributedCacheEntryOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
+                (_, data, _, _) => storedData = data)
+            .Returns(Task.CompletedTask);
+
+        cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => storedData);
+
+        var service = BuildService(cache: cacheMock.Object);
+        var reference = SampleReference();
+
+        var token = await service.CreateAsync("instance-42", "proof-of-identity-upload", reference);
+        var resolved = await service.ResolveAsync(token);
+
+        resolved.Should().NotBeNull();
+        resolved!.InstanceId.Should().Be("instance-42");
+        resolved.FieldKey.Should().Be("proof-of-identity-upload");
+        resolved.Reference.StorageKey.Should().Be(reference.StorageKey);
+        resolved.Reference.OriginalFileName.Should().Be(reference.OriginalFileName);
+        resolved.Reference.ContentType.Should().Be(reference.ContentType);
+        resolved.Reference.SizeBytes.Should().Be(reference.SizeBytes);
+    }
+}

--- a/src/UmbracoPrism.Core/Controllers/CmsWorkflowFileUploadController.cs
+++ b/src/UmbracoPrism.Core/Controllers/CmsWorkflowFileUploadController.cs
@@ -1,0 +1,105 @@
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Mvc;
+using UmbracoPrism.Core.Services;
+using UmbracoPrism.Core.Services.Workflow;
+using UmbracoPrism.Shared.Models.Workflow;
+
+namespace UmbracoPrism.Core.Controllers;
+
+/// <summary>
+/// Accepts a single <c>file-upload</c> field's file as soon as a visitor chooses it, ahead of
+/// the stage's own whole-page submission — the server half of the accessible progress-bar
+/// upload experience (<c>prism-file-upload.ts</c>). Saves the file immediately via the same
+/// <see cref="IWorkflowFileStorage"/> <see cref="PrismWorkflowPageController{TViewModel}.HandlePost"/>
+/// already uses, and hands back an opaque token bound to this exact instance/field
+/// (<see cref="IUploadTokenService"/>) for the client to carry in a hidden input until the real
+/// submission — see that method's own remarks for how it resolves the token back.
+/// </summary>
+/// <remarks>
+/// Same anonymous-at-the-framework-level, identity-resolved-and-ownership-checked security model
+/// as <see cref="CmsWorkflowFileDownloadController"/> — plus the same nonce-bound
+/// authoritative-fields check <c>HandlePost</c> performs for a whole-page submission, so an
+/// upload can't be aimed at a field that isn't actually part of the visitor's current stage.
+/// </remarks>
+[ApiController]
+[Route("prism/cms-workflow/upload")]
+public class CmsWorkflowFileUploadController(
+    CmsWorkflowEngine engine,
+    CmsWorkflowVisitorIdentityResolver identityResolver,
+    IWorkflowFileStorage fileStorage,
+    IWorkflowStepNonceService nonceService,
+    IUploadTokenService uploadTokenService,
+    IAntiforgery antiforgery) : ControllerBase
+{
+    // Kept in sync with PrismWorkflowPageController.DefaultMaxFileSizeBytes by hand — a plain
+    // literal here (rather than a cross-reference through that generic class) so this
+    // [RequestSizeLimit] attribute argument stays a straightforward compile-time constant.
+    private const long DefaultMaxFileSizeBytes = 10 * 1024 * 1024;
+
+    [HttpPost("{instanceId}/{fieldKey}")]
+    [RequestSizeLimit(DefaultMaxFileSizeBytes)]
+    public async Task<IActionResult> Upload(
+        string instanceId,
+        string fieldKey,
+        [FromForm] string nonce,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await antiforgery.ValidateRequestAsync(HttpContext);
+        }
+        catch (AntiforgeryValidationException)
+        {
+            return BadRequest("Invalid request.");
+        }
+
+        var authoritativeFields = await nonceService.ResolveAsync(nonce, cancellationToken);
+        var field = authoritativeFields?.FirstOrDefault(f =>
+            f.FieldKey.Equals(fieldKey, StringComparison.Ordinal)
+            && f.FieldType.Equals("file-upload", StringComparison.OrdinalIgnoreCase));
+        if (field is null)
+        {
+            // Covers an expired/unknown nonce and a field that isn't actually part of the
+            // current stage identically — a visitor never needs to distinguish the two.
+            return BadRequest("This field is no longer part of the current step.");
+        }
+
+        var (tenantId, userId) = identityResolver.Resolve();
+        if (!engine.IsOwnedInstance(instanceId, tenantId, userId, CmsWorkflowQueue.AccessProfile))
+        {
+            return NotFound();
+        }
+
+        var file = Request.Form.Files.GetFile("file");
+        if (file is null || file.Length == 0)
+        {
+            return BadRequest("No file was received.");
+        }
+
+        var maxSizeBytes = field.MaxSizeBytes ?? DefaultMaxFileSizeBytes;
+        if (file.Length > maxSizeBytes)
+        {
+            return BadRequest($"{field.Label} must be smaller than {maxSizeBytes / (1024 * 1024)}MB.");
+        }
+
+        if (field.AcceptedFileTypes is { Count: > 0 })
+        {
+            var extension = Path.GetExtension(file.FileName);
+            if (!field.AcceptedFileTypes.Contains(extension, StringComparer.OrdinalIgnoreCase))
+            {
+                return BadRequest($"{field.Label} must be one of: {string.Join(", ", field.AcceptedFileTypes)}.");
+            }
+        }
+
+        var reference = await fileStorage.SaveAsync(instanceId, fieldKey, file, cancellationToken);
+        var token = await uploadTokenService.CreateAsync(instanceId, fieldKey, reference, cancellationToken);
+
+        return Ok(new
+        {
+            token,
+            fileName = reference.OriginalFileName,
+            sizeBytes = reference.SizeBytes,
+            downloadUrl = $"/prism/cms-workflow/files/{Uri.EscapeDataString(instanceId)}/{Uri.EscapeDataString(fieldKey)}"
+        });
+    }
+}

--- a/src/UmbracoPrism.Core/Controllers/CmsWorkflowPageController.cs
+++ b/src/UmbracoPrism.Core/Controllers/CmsWorkflowPageController.cs
@@ -37,7 +37,8 @@ public class CmsWorkflowPageController(
     IAntiforgery antiforgery,
     IWorkflowStepNonceService nonceService,
     IWorkflowFieldValidator fieldValidator,
-    IWorkflowFileStorage fileStorage)
+    IWorkflowFileStorage fileStorage,
+    IUploadTokenService uploadTokenService)
     : PrismWorkflowPageController<PrismWorkflowViewModel>(
         logger,
         compositeViewEngine,
@@ -47,7 +48,8 @@ public class CmsWorkflowPageController(
         antiforgery,
         nonceService,
         fieldValidator,
-        fileStorage)
+        fileStorage,
+        uploadTokenService)
 {
     protected override bool RequiresAuthentication => false;
 }

--- a/src/UmbracoPrism.Core/Controllers/PrismWorkflowPageController.cs
+++ b/src/UmbracoPrism.Core/Controllers/PrismWorkflowPageController.cs
@@ -51,6 +51,7 @@ public abstract class PrismWorkflowPageController<TViewModel> : RenderController
     private readonly IWorkflowStepNonceService _nonceService;
     private readonly IWorkflowFieldValidator _fieldValidator;
     private readonly IWorkflowFileStorage _fileStorage;
+    private readonly IUploadTokenService _uploadTokenService;
 
     /// <summary>
     /// Initializes a new instance of the PrismWorkflowPageController class.
@@ -64,6 +65,7 @@ public abstract class PrismWorkflowPageController<TViewModel> : RenderController
     /// <param name="nonceService">Service for creating and resolving tamper-proof nonces bound to field definitions.</param>
     /// <param name="fieldValidator">Service for validating submitted field values against their server-side definitions.</param>
     /// <param name="fileStorage">Service for persisting files posted against <c>file-upload</c> fields.</param>
+    /// <param name="uploadTokenService">Resolves a field that was already uploaded asynchronously ahead of this submission.</param>
     protected PrismWorkflowPageController(
         ILogger<RenderController> logger,
         ICompositeViewEngine compositeViewEngine,
@@ -73,7 +75,8 @@ public abstract class PrismWorkflowPageController<TViewModel> : RenderController
         IAntiforgery antiforgery,
         IWorkflowStepNonceService nonceService,
         IWorkflowFieldValidator fieldValidator,
-        IWorkflowFileStorage fileStorage)
+        IWorkflowFileStorage fileStorage,
+        IUploadTokenService uploadTokenService)
         : base(logger, compositeViewEngine, umbracoContextAccessor)
     {
         _logger = logger;
@@ -83,6 +86,7 @@ public abstract class PrismWorkflowPageController<TViewModel> : RenderController
         _nonceService = nonceService;
         _fieldValidator = fieldValidator;
         _fileStorage = fileStorage;
+        _uploadTokenService = uploadTokenService;
     }
 
     /// <summary>
@@ -199,6 +203,9 @@ public abstract class PrismWorkflowPageController<TViewModel> : RenderController
         var nonce = form["Nonce"].ToString();
         var returnUrl = form["ReturnUrl"].ToString();
         var safeReturnUrl = GetSafeReturnUrl(returnUrl);
+        // Read here (rather than after validation, where the other hidden fields are read) —
+        // resolving an async-uploaded file's token below needs it too.
+        var instanceId = form["InstanceId"].ToString();
 
         if (string.IsNullOrEmpty(nonce))
         {
@@ -232,10 +239,58 @@ public abstract class PrismWorkflowPageController<TViewModel> : RenderController
             .Where(pair => pair.File is not null)
             .ToList();
 
+        // A file-upload field with no raw posted file may instead carry the opaque token
+        // CmsWorkflowFileUploadController issued when the visitor's browser uploaded it
+        // asynchronously ahead of this submission (prism-file-upload.ts) — resolve those here.
+        // A token is only trusted if it resolves at all AND its cached binding names this exact
+        // instance/field; anything else (expired, forged, copied from a different field or a
+        // different visitor's instance) is treated as if nothing were submitted at all by
+        // clearing it out of submittedFields, so the ordinary required-check below catches it
+        // the same way a genuinely-missing file would be caught.
+        var postedFileKeys = postedFiles.Select(pair => pair.Field.FieldKey).ToHashSet(StringComparer.Ordinal);
+        var tokenUploads = new List<(FieldRenderPayload Field, UploadTokenBinding Binding)>();
+        var validationOverrides = new Dictionary<string, string>();
+        foreach (var field in authoritativeFields.Where(f =>
+            f.FieldType.Equals("file-upload", StringComparison.OrdinalIgnoreCase) && !postedFileKeys.Contains(f.FieldKey)))
+        {
+            if (!submittedFields.TryGetValue(field.FieldKey, out var token) || string.IsNullOrWhiteSpace(token))
+            {
+                // Nothing submitted for this field at all this time round — a resubmit of a
+                // stage the visitor already satisfied earlier (e.g. editing a different field
+                // and continuing again) with no new choice made for THIS one. field.Value
+                // already reflects the instance's existing stored reference (the same value the
+                // "Uploaded: …" display state renders from), so let it satisfy the required
+                // check without touching fieldValues — leaving this key out of fieldValues
+                // entirely means the engine's own merge just preserves whatever's already there,
+                // the same way any other untouched field from an earlier stage is preserved.
+                if (!string.IsNullOrWhiteSpace(field.Value?.ToString()))
+                {
+                    validationOverrides[field.FieldKey] = field.Value!.ToString()!;
+                }
+                continue;
+            }
+
+            var binding = await _uploadTokenService.ResolveAsync(token);
+            if (binding is not null
+                && string.Equals(binding.InstanceId, instanceId, StringComparison.Ordinal)
+                && string.Equals(binding.FieldKey, field.FieldKey, StringComparison.Ordinal))
+            {
+                tokenUploads.Add((field, binding));
+            }
+            else
+            {
+                submittedFields[field.FieldKey] = string.Empty;
+            }
+        }
+
         var validationInput = new Dictionary<string, string>(submittedFields);
         foreach (var (field, _) in postedFiles)
         {
             validationInput[field.FieldKey] = "uploaded";
+        }
+        foreach (var (fieldKey, value) in validationOverrides)
+        {
+            validationInput[fieldKey] = value;
         }
 
         var validationResult = _fieldValidator.Validate(authoritativeFields, validationInput);
@@ -260,7 +315,6 @@ public abstract class PrismWorkflowPageController<TViewModel> : RenderController
             return Redirect(safeReturnUrl);
         }
 
-        var instanceId = form["InstanceId"].ToString();
         var workflowKey = form["WorkflowKey"].ToString();
         var action = form["Action"].ToString();
         var stateVersion = int.TryParse(form["StateVersion"], out var sv) ? sv : 0;
@@ -274,6 +328,12 @@ public abstract class PrismWorkflowPageController<TViewModel> : RenderController
         foreach (var (field, file) in postedFiles)
         {
             fieldValues[field.FieldKey] = await _fileStorage.SaveAsync(instanceId, field.FieldKey, file!);
+        }
+
+        // Already saved by the async upload endpoint — just swap the token for the real reference.
+        foreach (var (field, binding) in tokenUploads)
+        {
+            fieldValues[field.FieldKey] = binding.Reference;
         }
 
         // Combine GDS date sub-input parts (-day/-month/-year) into a display value

--- a/src/UmbracoPrism.Core/Extensions/CmsWorkflowBuilderExtensions.cs
+++ b/src/UmbracoPrism.Core/Extensions/CmsWorkflowBuilderExtensions.cs
@@ -86,6 +86,10 @@ public static class CmsWorkflowBuilderExtensions
         // a host can replace this registration with its own (blob storage, etc.).
         services.AddSingleton<IWorkflowFileStorage, DiskWorkflowFileStorage>();
 
+        // Binds an async-uploaded file to the opaque token the client carries until the stage's
+        // real POST — same IDistributedCache mechanism as the nonce service.
+        services.AddSingleton<IUploadTokenService, UploadTokenService>();
+
         services.AddHostedService<PrismCmsWorkflowInstanceSweepService>();
 
         return services;

--- a/src/UmbracoPrism.Core/Models/Workflow/PrismFieldContext.cs
+++ b/src/UmbracoPrism.Core/Models/Workflow/PrismFieldContext.cs
@@ -21,6 +21,16 @@ public record PrismFieldContext
     public string InstanceId { get; init; } = string.Empty;
 
     /// <summary>
+    /// The current step's nonce — needed by a <c>file-upload</c> field's partial to authorize
+    /// its own async upload request against the same authoritative-fields check
+    /// <c>HandlePost</c> already performs for the whole-page submission.
+    /// </summary>
+    public string Nonce { get; init; } = string.Empty;
+
+    /// <summary>The current workflow key — needed by a <c>file-upload</c> field's async upload URL.</summary>
+    public string WorkflowKey { get; init; } = string.Empty;
+
+    /// <summary>
     /// The value to display in the field — resolved from submitted values,
     /// then DefaultValue, then the engine-provided Value.
     /// </summary>
@@ -73,7 +83,9 @@ public record PrismFieldContext
         FieldRenderPayload field,
         string? fieldError,
         IReadOnlyDictionary<string, string>? values,
-        string instanceId = "")
+        string instanceId = "",
+        string nonce = "",
+        string workflowKey = "")
     {
         var submittedValue = values?.GetValueOrDefault(field.FieldKey);
         var displayValue   = !string.IsNullOrWhiteSpace(field.DefaultValue)
@@ -117,6 +129,8 @@ public record PrismFieldContext
             WrapperClass = wrapperClass,
             WrapperAttrs = wrapperAttrs,
             InstanceId   = instanceId,
+            Nonce        = nonce,
+            WorkflowKey  = workflowKey,
         };
     }
 }

--- a/src/UmbracoPrism.Core/Models/Workflow/PrismWorkflowViewModel.cs
+++ b/src/UmbracoPrism.Core/Models/Workflow/PrismWorkflowViewModel.cs
@@ -120,4 +120,14 @@ public class PrismWorkflowViewModel : PublishedContentWrapped
             .SelectMany(c => c.Fields ?? Array.Empty<FieldRenderPayload>())
             .ToList();
 
+    /// <summary>
+    /// True when this step renders at least one <c>file-upload</c> field — gates whether the
+    /// view includes <c>prism-file-upload.js</c>, the same way <see cref="LiveModelJson"/>
+    /// already gates <c>prism-live-form.js</c>. Derived purely from <see cref="AllFields"/>
+    /// (already on this model), unlike <see cref="LiveModelJson"/>, which needs the controller's
+    /// own involvement because it comes from a separate render-data key.
+    /// </summary>
+    public bool HasFileUploadField =>
+        AllFields.Any(f => f.FieldType.Equals("file-upload", StringComparison.OrdinalIgnoreCase));
+
 }

--- a/src/UmbracoPrism.Core/Services/Workflow/CmsWorkflowEngine.cs
+++ b/src/UmbracoPrism.Core/Services/Workflow/CmsWorkflowEngine.cs
@@ -53,4 +53,20 @@ public sealed class CmsWorkflowEngine(
             ? WorkflowFileReference.FromFieldValue(raw)
             : null;
     }
+
+    /// <summary>
+    /// The same ownership check <see cref="TryGetOwnedFileReference"/> performs, for a caller
+    /// that needs to authorize against an instance before any file exists yet — the async
+    /// upload endpoint, which must verify the requester owns the instance it's about to write a
+    /// new file against.
+    /// </summary>
+    public bool IsOwnedInstance(
+        string instanceId,
+        string tenantId,
+        string userId,
+        WorkflowAccessProfile accessProfile)
+    {
+        return instanceStore.TryGet(instanceId, out var instance)
+            && CanAccessInstance(instance, tenantId, userId, accessProfile);
+    }
 }

--- a/src/UmbracoPrism.Core/Services/Workflow/IUploadTokenService.cs
+++ b/src/UmbracoPrism.Core/Services/Workflow/IUploadTokenService.cs
@@ -1,0 +1,33 @@
+using UmbracoPrism.Shared.Models.Workflow;
+
+namespace UmbracoPrism.Core.Services;
+
+/// <summary>
+/// Binds a file already saved by the async upload endpoint to an opaque, short-lived token a
+/// client carries in a hidden field — so the stage's eventual whole-page submission
+/// (<c>PrismWorkflowPageController.HandlePost</c>) can recognize "this field is already
+/// satisfied" without re-uploading the bytes. Mirrors <see cref="IWorkflowStepNonceService"/>'s
+/// shape exactly, for the same reason: a random, server-issued, cache-backed token that only
+/// resolves to something meaningful for the requester who was just issued it.
+/// </summary>
+public interface IUploadTokenService
+{
+    /// <summary>Caches an uploaded file's reference, scoped to the instance/field it belongs to, and returns a fresh token.</summary>
+    Task<string> CreateAsync(string instanceId, string fieldKey, WorkflowFileReference reference, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves a token back to its binding. Returns <see langword="null"/> if the token has
+    /// expired or never existed. Callers must still confirm the returned binding's
+    /// <c>InstanceId</c>/<c>FieldKey</c> match the current request before trusting it — this
+    /// only proves the token is real, not that it belongs to this exact field.
+    /// </summary>
+    Task<UploadTokenBinding?> ResolveAsync(string token, CancellationToken ct = default);
+}
+
+/// <summary>What an upload token actually grants — the file, and which instance/field it was uploaded for.</summary>
+public sealed record UploadTokenBinding
+{
+    public required string InstanceId { get; init; }
+    public required string FieldKey { get; init; }
+    public required WorkflowFileReference Reference { get; init; }
+}

--- a/src/UmbracoPrism.Core/Services/Workflow/UploadTokenService.cs
+++ b/src/UmbracoPrism.Core/Services/Workflow/UploadTokenService.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
+using UmbracoPrism.Core.Configuration;
+using UmbracoPrism.Shared.Models.Workflow;
+
+namespace UmbracoPrism.Core.Services;
+
+/// <summary>
+/// <see cref="IUploadTokenService"/> backed by <see cref="IDistributedCache"/> — same mechanism
+/// and TTL (<see cref="PrismWorkflowOptions.NonceExpiry"/>) as <see cref="WorkflowStepNonceService"/>,
+/// since an uploaded-but-not-yet-submitted file is scoped to the same single stage visit a nonce is.
+/// </summary>
+public class UploadTokenService : IUploadTokenService
+{
+    private readonly IDistributedCache _cache;
+    private readonly PrismWorkflowOptions _options;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    public UploadTokenService(IDistributedCache cache, IOptions<PrismWorkflowOptions> options)
+    {
+        _cache = cache;
+        _options = options.Value;
+    }
+
+    public async Task<string> CreateAsync(string instanceId, string fieldKey, WorkflowFileReference reference, CancellationToken ct = default)
+    {
+        var token = Guid.NewGuid().ToString("N");
+        var cacheKey = $"prism:workflow:upload-token:{token}";
+
+        var binding = new UploadTokenBinding { InstanceId = instanceId, FieldKey = fieldKey, Reference = reference };
+        var json = JsonSerializer.SerializeToUtf8Bytes(binding, JsonOptions);
+
+        var cacheOptions = new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = _options.NonceExpiry
+        };
+
+        await _cache.SetAsync(cacheKey, json, cacheOptions, ct);
+
+        return token;
+    }
+
+    public async Task<UploadTokenBinding?> ResolveAsync(string token, CancellationToken ct = default)
+    {
+        var cacheKey = $"prism:workflow:upload-token:{token}";
+
+        var json = await _cache.GetAsync(cacheKey, ct);
+
+        return json == null ? null : JsonSerializer.Deserialize<UploadTokenBinding>(json, JsonOptions);
+    }
+}

--- a/src/UmbracoPrism.Core/TagHelpers/PrismComponentTagHelper.cs
+++ b/src/UmbracoPrism.Core/TagHelpers/PrismComponentTagHelper.cs
@@ -149,7 +149,7 @@ public class PrismComponentTagHelper : TagHelper
         }
 
         var fieldError = Errors?.GetValueOrDefault(Field.FieldKey);
-        var ctx        = PrismFieldContext.Build(Field, fieldError, Values, InstanceId);
+        var ctx        = PrismFieldContext.Build(Field, fieldError, Values, InstanceId, Nonce, WorkflowKey);
         var partial    = ResolveFieldPartial(fieldType);
         var content    = await _htmlHelper.PartialAsync(partial, ctx);
 

--- a/src/UmbracoPrism.Core/Views/Partials/PrismComponents/_PrismComponent-Accordion.cshtml
+++ b/src/UmbracoPrism.Core/Views/Partials/PrismComponents/_PrismComponent-Accordion.cshtml
@@ -33,7 +33,7 @@
                     {
                         @foreach (var field in accordionSection.Fields)
                         {
-                            <prism-field field="@field" errors="@Model.Errors" values="@Model.Values" instance-id="@Model.InstanceId" />
+                            <prism-field field="@field" errors="@Model.Errors" values="@Model.Values" instance-id="@Model.InstanceId" nonce="@Model.Nonce" workflow-key="@Model.WorkflowKey" />
                         }
                     }
                     else if (!string.IsNullOrEmpty(accordionSection.Content))

--- a/src/UmbracoPrism.Core/Views/Partials/PrismComponents/_PrismComponent-Fieldset.cshtml
+++ b/src/UmbracoPrism.Core/Views/Partials/PrismComponents/_PrismComponent-Fieldset.cshtml
@@ -11,7 +11,7 @@
     @* Single-question page pattern — no fieldset wrapper *@
     @foreach (var field in fields)
     {
-        <prism-field field="@field" errors="@Model.Errors" values="@Model.Values" instance-id="@Model.InstanceId" />
+        <prism-field field="@field" errors="@Model.Errors" values="@Model.Values" instance-id="@Model.InstanceId" nonce="@Model.Nonce" workflow-key="@Model.WorkflowKey" />
     }
 }
 else if (!string.IsNullOrEmpty(legend))
@@ -22,7 +22,7 @@ else if (!string.IsNullOrEmpty(legend))
         </legend>
         @foreach (var field in fields)
         {
-            <prism-field field="@field" errors="@Model.Errors" values="@Model.Values" instance-id="@Model.InstanceId" />
+            <prism-field field="@field" errors="@Model.Errors" values="@Model.Values" instance-id="@Model.InstanceId" nonce="@Model.Nonce" workflow-key="@Model.WorkflowKey" />
         }
     </fieldset>
 }
@@ -30,6 +30,6 @@ else
 {
     @foreach (var field in fields)
     {
-        <prism-field field="@field" errors="@Model.Errors" values="@Model.Values" instance-id="@Model.InstanceId" />
+        <prism-field field="@field" errors="@Model.Errors" values="@Model.Values" instance-id="@Model.InstanceId" nonce="@Model.Nonce" workflow-key="@Model.WorkflowKey" />
     }
 }

--- a/src/UmbracoPrism.Core/Views/Partials/PrismFields/_Component-FileUpload.cshtml
+++ b/src/UmbracoPrism.Core/Views/Partials/PrismFields/_Component-FileUpload.cshtml
@@ -3,27 +3,80 @@
     var acceptAttr = Model.Field.AcceptedFileTypes is { Count: > 0 }
         ? $@" accept=""{string.Join(",", Model.Field.AcceptedFileTypes)}"""
         : string.Empty;
+    var acceptList = Model.Field.AcceptedFileTypes is { Count: > 0 }
+        ? string.Join(",", Model.Field.AcceptedFileTypes)
+        : string.Empty;
+    // Kept in sync with PrismWorkflowPageController.DefaultMaxFileSizeBytes by hand (10MB) —
+    // same tradeoff as CmsWorkflowFileUploadController's own local copy of this constant.
+    var maxSizeBytes = Model.Field.MaxSizeBytes ?? 10 * 1024 * 1024;
     var alreadyUploaded = !string.IsNullOrEmpty(Model.DisplayValue);
     var downloadUrl = alreadyUploaded && !string.IsNullOrEmpty(Model.InstanceId)
         ? $"/prism/cms-workflow/files/{Uri.EscapeDataString(Model.InstanceId)}/{Uri.EscapeDataString(Model.Field.FieldKey)}"
         : null;
+    var uploadUrl = $"/prism/cms-workflow/upload/{Uri.EscapeDataString(Model.InstanceId)}/{Uri.EscapeDataString(Model.Field.FieldKey)}";
 }
-<div class="@Model.WrapperClass"@Html.Raw(Model.WrapperAttrs)>
+@* prism-file-upload.ts progressively enhances this into: choose a file -> real upload with an
+   accessible progress bar -> "Uploaded: name — View — Change", all client-side, before the
+   stage's own Continue button is ever pressed. Every data-prism-file-upload-* hook below is that
+   script's contract with this markup; changing one without the other will silently break it. *@
+<div class="@Model.WrapperClass"@Html.Raw(Model.WrapperAttrs)
+     data-prism-file-upload
+     data-prism-upload-url="@uploadUrl"
+     data-prism-nonce="@Model.Nonce"
+     data-prism-field-key="@Model.Field.FieldKey"
+     data-prism-max-size="@maxSizeBytes"
+     data-prism-accept="@acceptList"
+     data-prism-label="@Model.Field.Label">
     @await Html.PartialAsync("~/Views/Partials/PrismFields/_ComponentLabel.cshtml", Model)
-    @if (alreadyUploaded)
-    {
-        <p class="govuk-body">
-            Uploaded: @Model.DisplayValue
-            @if (downloadUrl is not null)
-            {
-                <text> — <a class="govuk-link" href="@downloadUrl" target="_blank" rel="noopener">View</a></text>
-            }
+
+    @* The filename span and View link always exist in the DOM (even on a page that's never had
+       an upload) — prism-file-upload.ts populates both itself the moment a real upload
+       completes, so it never needs to build DOM nodes from scratch, only fill in ones already
+       here. *@
+    <div data-prism-file-upload-uploaded@(alreadyUploaded ? "" : " hidden")>
+        <p class="govuk-body" data-prism-file-upload-uploaded-text>
+            Uploaded: <span data-prism-file-upload-filename>@Model.DisplayValue</span>
+            — <a class="govuk-link" data-prism-file-upload-view-link href="@(downloadUrl ?? "#")" target="_blank" rel="noopener"@(downloadUrl is null ? " hidden" : "")>View</a>
         </p>
-        <p class="govuk-hint">Choose a file below to replace it.</p>
-    }
+        <button type="button" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-2" data-module="govuk-button" data-prism-file-upload-change>
+            Choose a different file
+        </button>
+    </div>
+
+    <div class="prism-file-upload-progress" data-prism-file-upload-progress hidden>
+        <p class="govuk-body" data-prism-file-upload-progress-label>Uploading @Model.Field.Label…</p>
+        <div class="prism-file-upload-progress-track"
+             role="progressbar"
+             aria-valuemin="0"
+             aria-valuemax="100"
+             aria-valuenow="0"
+             aria-label="Upload progress for @Model.Field.Label"
+             data-prism-file-upload-progress-bar>
+            <div class="prism-file-upload-progress-fill" data-prism-file-upload-progress-fill></div>
+        </div>
+        <span class="govuk-visually-hidden" aria-live="polite" data-prism-file-upload-progress-announce></span>
+    </div>
+
+    <p class="govuk-error-message" data-prism-file-upload-error hidden></p>
+
+    @* disabled (not just hidden) whenever a file is already uploaded — an unselected
+       <input type="file"> still submits an empty-but-present multipart part under this same
+       "fields[...]" name, which would silently overwrite the real existing reference with a
+       zero-byte one on any resubmit that doesn't touch this field. Only "Choose a different
+       file" (prism-file-upload.ts's showEmpty()) re-enables it. With neither this input nor the
+       token input below submitting anything, HandlePost's own fallback — field.Value already
+       being non-empty is treated as "already satisfied" without touching fieldValues — is what
+       correctly leaves the existing reference untouched. *@
     <input class="govuk-file-upload@(Model.HasFieldError ? " govuk-file-upload--error" : "")"
            type="file"
            id="@Model.Field.FieldKey"
            name="fields[@Model.Field.FieldKey]"
-           data-label="@Model.Field.Label"@Html.Raw(acceptAttr)@Html.Raw(Model.DescribedBy)@Html.Raw(Model.AriaRequired)@Html.Raw(Model.AriaInvalid) />
+           data-prism-file-upload-input
+           data-label="@Model.Field.Label"@Html.Raw(acceptAttr)@Html.Raw(Model.DescribedBy)@Html.Raw(Model.AriaRequired)@Html.Raw(Model.AriaInvalid)
+           @(alreadyUploaded ? "hidden disabled" : "") />
+
+    @* Carries the async-issued token once uploaded — the field's real submitted value.
+       Disabled (so it isn't posted) whenever neither this nor the raw input above has anything
+       real to submit for this field. *@
+    <input type="hidden" name="fields[@Model.Field.FieldKey]" data-prism-file-upload-token disabled value="" />
 </div>

--- a/src/UmbracoPrism.Core/Views/Partials/_WorkflowStep-Question.cshtml
+++ b/src/UmbracoPrism.Core/Views/Partials/_WorkflowStep-Question.cshtml
@@ -26,6 +26,11 @@
         <script type="application/json" data-prism-live-model>@Html.Raw(Model.LiveModelJson!.Replace("</", "<\\/"))</script>
     }
 
+    @if (Model.HasFileUploadField)
+    {
+        <script type="module" src="/App_Plugins/UmbracoPrism/dist/prism-file-upload.js"></script>
+    }
+
     <div class="govuk-button-group">
         @foreach (var action in Model.AvailableActions)
         {

--- a/src/UmbracoPrism.TestSite/Controllers/WorkflowPageController.cs
+++ b/src/UmbracoPrism.TestSite/Controllers/WorkflowPageController.cs
@@ -29,7 +29,8 @@ public class WorkflowPageController(
     IAntiforgery antiforgery,
     IWorkflowStepNonceService nonceService,
     IWorkflowFieldValidator fieldValidator,
-    IWorkflowFileStorage fileStorage)
+    IWorkflowFileStorage fileStorage,
+    IUploadTokenService uploadTokenService)
     : PrismWorkflowPageController<WorkflowViewModel>(
         logger,
         compositeViewEngine,
@@ -39,7 +40,8 @@ public class WorkflowPageController(
         antiforgery,
         nonceService,
         fieldValidator,
-        fileStorage)
+        fileStorage,
+        uploadTokenService)
 {
     /// <summary>
     /// Pre-populates workflow fields from authenticated user claims.


### PR DESCRIPTION
## Summary
Replaces the file-upload component's plain synchronous submission with an accessible upload experience: choosing a file uploads it immediately via `XMLHttpRequest` (real `upload.onprogress` events), with a `role="progressbar"` bar and throttled `aria-live` announcements, before the stage's own Continue button is ever pressed.

- New `CmsWorkflowFileUploadController` — accepts one field's file ahead of the main submission, same identity/ownership checks as the existing download controller, plus the same nonce-bound authoritative-fields check `HandlePost` already performs.
- New `UploadTokenService` (mirrors `WorkflowStepNonceService`) — binds the saved file to a short-lived opaque token the client carries in a hidden input until the real submission.
- `HandlePost` resolves the token back to the already-saved file, only trusting a token whose cached binding names the exact instance/field.
- New `prism-file-upload.ts` — generic, boots independently of `prism-live-form.ts` (a stage can have file-upload fields with no calculations block), gated by a new `PrismWorkflowViewModel.HasFileUploadField` computed property mirroring how `LiveModelJson` already gates its own script tag.
- No no-JS fallback for this component specifically (confirmed acceptable — JS is compatible with WCAG AA); every other stage in this engine still works without JS.

Also fixes two real, adjacent bugs found live while building this:
- Resubmitting a stage without re-choosing an already-uploaded file used to fail required-validation (no fallback to the field's own existing value).
- That same "no new file chosen" case was actually **clobbering** the real reference with a zero-byte one, because an unselected `<input type="file">` still submits an empty-but-present multipart part under the same field name. Both the native input and the token input are now `disabled` (not just hidden) whenever they have nothing real to submit.

## Test plan
- [x] `dotnet test src/UmbracoPrism.Core.Tests/` — 997 passed (8 new for `UploadTokenService`)
- [x] `npx tsc --noEmit` clean; `npm run build` clean
- [x] Live verification against a clean Aspire boot: oversized/wrong-extension files rejected inline with no page reload; a real upload shows genuine incremental progress under artificial network throttling with correct `aria-live` announcements; "Choose a different file" resets state; a full stage submission with all required fields uploaded reaches Check Your Answers with correct filenames/View links; resubmitting without touching an already-uploaded field now correctly preserves it (previously broken, confirmed via direct repro before and after the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFkBGMUmY8gxspjrPdFB4Q