### PR TITLE
ci: fail the release workflow if package versions don't match the tag

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -16,6 +16,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify package version matches release tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG="${{ github.ref_name }}"
+          TAG_VERSION="${TAG#v}"
+
+          CORE_VERSION=$(grep -oE '<Version>[^<]+</Version>' src/UmbracoPrism.Core/UmbracoPrism.Core.csproj | head -1 | sed -E 's#</?Version>##g')
+          CLIENT_VERSION=$(grep -oE '"version": *"[^"]+"' src/UmbracoPrism.Client/package.json | head -1 | sed -E 's/"version": *"([^"]+)"/\1/')
+
+          echo "Tag version:          $TAG_VERSION"
+          echo "Core.csproj version:  $CORE_VERSION"
+          echo "Client package.json:  $CLIENT_VERSION"
+
+          if [ "$TAG_VERSION" != "$CORE_VERSION" ]; then
+            echo "::error::Tag ${TAG} does not match UmbracoPrism.Core.csproj <Version>${CORE_VERSION}</Version>. The version file was not bumped for this release — refusing to pack, since this would silently try to re-push an already-published version to NuGet (as happened with v1.13.0, which packed and rejected as a duplicate of 1.12.0)."
+            exit 1
+          fi
+
+          if [ "$TAG_VERSION" != "$CLIENT_VERSION" ]; then
+            echo "::error::Tag ${TAG} does not match src/UmbracoPrism.Client/package.json version ${CLIENT_VERSION}. Both version files must be bumped together for a release."
+            exit 1
+          fi
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Why

While publishing v1.14.0, I found that v1.13.0's release never actually made it to NuGet — the workflow ran to completion (GitHub release created, tag pushed) but the version files were never bumped for that release, so it packed and tried to push `UmbracoPrism.1.12.0.nupkg` again. NuGet correctly rejected it with `409 Conflict` (already published), and nothing in the workflow noticed or failed loudly — the release just silently never published.

## What this does

Adds a guard step immediately after checkout, before any build/pack work: compares the pushed tag (`v{x.y.z}`) against both `UmbracoPrism.Core.csproj`'s `<Version>` and `Client/package.json`'s `"version"`. Fails fast with a clear `::error::` naming exactly which file is out of sync, instead of letting this surface later as an opaque NuGet 409 — or not surface at all.

Deliberately doesn't add `--skip-duplicate` to the NuGet push step — that would make this exact failure mode softer and quieter, the opposite of what's needed.

## Verification

Tested the guard's shell logic locally (not just eyeballed):
- Passes against the current, correctly-bumped v1.14.0 version files.
- Correctly fails when re-run against the v1.13.0 scenario's stale 1.12.0 versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)