### PR TITLE
feat: claim anonymous CMS Workflow instances on sign-in

### DIFF
--- a/src/UmbracoPrism.Client/tests/localhost-auth-session.spec.ts
+++ b/src/UmbracoPrism.Client/tests/localhost-auth-session.spec.ts
@@ -49,6 +49,37 @@ test.describe('Localhost auth/session behavioural contracts', () => {
     );
   });
 
+  test('anonymous CMS Workflow instance is claimed and resumable after signing in', async ({ page }) => {
+    // Start "Apply for a juggling licence" anonymously — no sign-in yet.
+    await page.goto('/apply-for-a-juggling-licence');
+    await page.getByLabel('I confirm I am aged 16 or over').check();
+    await page.getByLabel('I confirm I have a UK postal address').check();
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await expect(page.getByRole('heading', { name: 'Your details' })).toBeVisible();
+
+    const anonymousCookie = (await page.context().cookies()).find(c => c.name === 'PrismCmsWorkflowVisitor');
+    expect(anonymousCookie, 'starting a CMS Workflow anonymously must set the visitor correlation cookie').toBeTruthy();
+
+    // Sign in — same browser context, so the anonymous cookie rides along with the sign-in
+    // request and the server-side claim hook can see both identities together.
+    await signIn(page);
+
+    // The claim succeeded: the anonymous cookie is gone (nothing left to correlate against —
+    // the instance now belongs to the signed-in member) and it shows up as resumable.
+    const cookiesAfterSignIn = await page.context().cookies();
+    expect(cookiesAfterSignIn.some(c => c.name === 'PrismCmsWorkflowVisitor')).toBe(false);
+
+    await page.goto('/my-workflows');
+    await expect(page.getByRole('heading', { name: 'In Progress' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Apply for a juggling licence', level: 3 })).toBeVisible();
+    await expect(page.getByText('Your details')).toBeVisible();
+
+    // Resuming lands back on the exact step left off, not a fresh restart.
+    await page.getByRole('link', { name: 'Continue' }).click();
+    await expect(page).toHaveURL(/\/apply-for-a-juggling-licence\/?\?instanceId=/);
+    await expect(page.getByRole('heading', { name: 'Your details' })).toBeVisible();
+  });
+
   test('signed-in member can open the seeded workflow start page', async ({ page }) => {
     await signIn(page);
     await page.goto('/get-in-touch');

--- a/src/UmbracoPrism.Core.Tests/Workflow/Runtime/InProcessCmsWorkflowClientTests.cs
+++ b/src/UmbracoPrism.Core.Tests/Workflow/Runtime/InProcessCmsWorkflowClientTests.cs
@@ -25,20 +25,21 @@ public class InProcessCmsWorkflowClientTests
         var sanitizer = new Mock<IWorkflowContentSanitizer>();
         sanitizer.Setup(s => s.Sanitize(It.IsAny<string>())).Returns<string>(x => x);
 
+        var httpContext = new DefaultHttpContext();
+        var accessor = new Mock<IHttpContextAccessor>();
+        accessor.Setup(a => a.HttpContext).Returns(httpContext);
+
         var engine = new CmsWorkflowEngine(
             NullLogger<CmsWorkflowEngine>.Instance,
             new EmptyDefinitionStore(),
             sanitizer.Object,
-            new InMemoryWorkflowInstanceStore());
+            new InMemoryWorkflowInstanceStore(),
+            accessor.Object);
 
         var userContext = new Mock<IPrismUserContext>();
         userContext.Setup(u => u.IsAuthenticated).Returns(authenticated);
         userContext.Setup(u => u.Email).Returns(email);
         userContext.Setup(u => u.CurrentTenant).Returns(new PrismTenant { Hostname = "example.test" });
-
-        var httpContext = new DefaultHttpContext();
-        var accessor = new Mock<IHttpContextAccessor>();
-        accessor.Setup(a => a.HttpContext).Returns(httpContext);
 
         var identityResolver = new CmsWorkflowVisitorIdentityResolver(userContext.Object, accessor.Object);
         var client = new InProcessCmsWorkflowClient(engine, identityResolver);

--- a/src/UmbracoPrism.Core.Tests/Workflow/Runtime/UmbracoCmsWorkflowInstanceStoreTests.cs
+++ b/src/UmbracoPrism.Core.Tests/Workflow/Runtime/UmbracoCmsWorkflowInstanceStoreTests.cs
@@ -129,6 +129,106 @@ public class UmbracoCmsWorkflowInstanceStoreTests
     }
 
     [Fact]
+    public void Save_AuthenticatedInstance_NewRow_InsertsWithNeverExpiresInsteadOfSlidingWindow()
+    {
+        var (store, db) = BuildStore();
+        db.Setup(d => d.Execute(
+                It.Is<string>(sql => sql.StartsWith("UPDATE prismCmsWorkflowInstance SET WorkflowKey")),
+                It.IsAny<object[]>()))
+            .Returns(0);
+
+        store.Save(new WorkflowInstanceState
+        {
+            InstanceId = "instance-1",
+            WorkflowKey = "apply-for-a-juggling-licence",
+            TenantId = "tenant-1",
+            UserId = "member@example.test",
+            IsAuthenticated = true,
+            CurrentState = "eligibility"
+        });
+
+        db.Verify(d => d.Insert(It.Is<PrismCmsWorkflowInstanceSchema>(r =>
+            r.InstanceId == "instance-1" && r.ExpiresUtc == DateTime.MaxValue)), Times.Once);
+    }
+
+    [Fact]
+    public void Save_AuthenticatedInstance_ExistingRow_UpdatesWithNeverExpires()
+    {
+        var (store, db) = BuildStore();
+        DateTime? capturedExpiresUtc = null;
+        db.Setup(d => d.Execute(
+                It.Is<string>(sql => sql.StartsWith("UPDATE prismCmsWorkflowInstance SET WorkflowKey")),
+                It.IsAny<object[]>()))
+            .Callback<string, object[]>((_, args) => capturedExpiresUtc = (DateTime)args[4])
+            .Returns(1);
+
+        store.Save(new WorkflowInstanceState
+        {
+            InstanceId = "instance-1",
+            WorkflowKey = "apply-for-a-juggling-licence",
+            TenantId = "tenant-1",
+            UserId = "member@example.test",
+            IsAuthenticated = true,
+            CurrentState = "check-answers"
+        });
+
+        capturedExpiresUtc.Should().Be(DateTime.MaxValue);
+    }
+
+    [Fact]
+    public void Save_AnonymousInstance_StillUsesTheSlidingWindow()
+    {
+        var (store, db) = BuildStore();
+        DateTime? capturedExpiresUtc = null;
+        db.Setup(d => d.Execute(
+                It.Is<string>(sql => sql.StartsWith("UPDATE prismCmsWorkflowInstance SET WorkflowKey")),
+                It.IsAny<object[]>()))
+            .Callback<string, object[]>((_, args) => capturedExpiresUtc = (DateTime)args[4])
+            .Returns(1);
+
+        store.Save(new WorkflowInstanceState
+        {
+            InstanceId = "instance-1",
+            WorkflowKey = "apply-for-a-juggling-licence",
+            TenantId = "tenant-1",
+            UserId = "anon-cookie-1",
+            IsAuthenticated = false,
+            CurrentState = "check-answers"
+        });
+
+        capturedExpiresUtc.Should().NotBe(DateTime.MaxValue);
+        capturedExpiresUtc.Should().BeCloseTo(DateTime.UtcNow.AddMinutes(30), TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void TryGet_AuthenticatedInstance_DoesNotRefreshTheAlreadyPermanentExpiry()
+    {
+        var (store, db) = BuildStore();
+        var row = BuildRow("instance-1", DateTime.MaxValue);
+        row.StateJson = JsonSerializer.Serialize(new WorkflowInstanceState
+        {
+            InstanceId = "instance-1",
+            WorkflowKey = "apply-for-a-juggling-licence",
+            TenantId = "tenant-1",
+            UserId = "member@example.test",
+            IsAuthenticated = true,
+            CurrentState = "eligibility"
+        });
+        db.Setup(d => d.FirstOrDefault<PrismCmsWorkflowInstanceSchema>(
+                It.IsAny<string>(), It.IsAny<object[]>()))
+            .Returns(row);
+
+        var found = store.TryGet("instance-1", out var instance);
+
+        found.Should().BeTrue();
+        instance.IsAuthenticated.Should().BeTrue();
+        db.Verify(d => d.Execute(
+            It.Is<string>(sql => sql.Contains("UPDATE prismCmsWorkflowInstance SET ExpiresUtc")),
+            It.IsAny<object[]>()), Times.Never,
+            "an already-permanent row needs no sliding-window refresh — that would just be a wasted write");
+    }
+
+    [Fact]
     public void Remove_DeletesByInstanceId()
     {
         var (store, db) = BuildStore();

--- a/src/UmbracoPrism.Core.Tests/Workflow/Runtime/WorkflowRuntimeEngineInstanceStoreTests.cs
+++ b/src/UmbracoPrism.Core.Tests/Workflow/Runtime/WorkflowRuntimeEngineInstanceStoreTests.cs
@@ -86,6 +86,79 @@ public class WorkflowRuntimeEngineInstanceStoreTests
     }
 
     [Fact]
+    public void GetCurrent_StartNew_DefaultsIsAuthenticatedToFalse()
+    {
+        // The base engine has no identity model of its own — ResolveIsAuthenticated is only
+        // ever true when a host (e.g. CmsWorkflowEngine) overrides it.
+        var store = new RecordingWorkflowInstanceStore();
+        var engine = CreateEngine(store);
+
+        var envelope = engine.GetCurrent("test-workflow", Tenant, User, action: "start-new");
+
+        store.TryGet(envelope.InstanceId, out var stored).Should().BeTrue();
+        stored.IsAuthenticated.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetCurrent_StartNew_HostOverridingResolveIsAuthenticated_StampsTheNewInstance()
+    {
+        var store = new RecordingWorkflowInstanceStore();
+        var sanitizer = new Mock<IWorkflowContentSanitizer>();
+        sanitizer.Setup(s => s.Sanitize(It.IsAny<string>())).Returns<string>(x => x);
+        var engine = new AlwaysAuthenticatedWorkflowRuntimeEngine(
+            NullLogger<AlwaysAuthenticatedWorkflowRuntimeEngine>.Instance,
+            new SingleDefinitionStore(BuildDefinition()),
+            sanitizer.Object,
+            store);
+
+        var envelope = engine.GetCurrent("test-workflow", Tenant, User, action: "start-new");
+
+        store.TryGet(envelope.InstanceId, out var stored).Should().BeTrue();
+        stored.IsAuthenticated.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ClaimInstances_AnonymousInstanceWithNoConflict_IsRekeyedAndMarkedAuthenticated()
+    {
+        var store = new RecordingWorkflowInstanceStore();
+        var engine = CreateEngine(store);
+        store.Save(CreateInstance("anon-instance", "start") with { UserId = "anon-cookie-1" });
+
+        var claimed = engine.ClaimInstances(Tenant, "anon-cookie-1", "member@example.test");
+
+        claimed.Should().ContainSingle().Which.Should().Be("anon-instance");
+        store.TryGet("anon-instance", out var stored).Should().BeTrue();
+        stored.UserId.Should().Be("member@example.test");
+        stored.IsAuthenticated.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ClaimInstances_MemberAlreadyOwnsAnInstanceOfThatWorkflow_LeavesTheAnonymousOneUnclaimed()
+    {
+        var store = new RecordingWorkflowInstanceStore();
+        var engine = CreateEngine(store);
+        store.Save(CreateInstance("anon-instance", "start") with { UserId = "anon-cookie-1" });
+        store.Save(CreateInstance("members-own-instance", "start") with { UserId = "member@example.test", IsAuthenticated = true });
+
+        var claimed = engine.ClaimInstances(Tenant, "anon-cookie-1", "member@example.test");
+
+        claimed.Should().BeEmpty();
+        store.TryGet("anon-instance", out var stillAnonymous).Should().BeTrue();
+        stillAnonymous.UserId.Should().Be("anon-cookie-1", "claiming must not overwrite the member's own existing instance");
+    }
+
+    [Fact]
+    public void ClaimInstances_NoAnonymousInstances_ReturnsEmptyWithoutError()
+    {
+        var store = new RecordingWorkflowInstanceStore();
+        var engine = CreateEngine(store);
+
+        var claimed = engine.ClaimInstances(Tenant, "anon-cookie-with-nothing", "member@example.test");
+
+        claimed.Should().BeEmpty();
+    }
+
+    [Fact]
     public void NoInstanceStoreSupplied_DefaultsToProcessLocalInMemoryBehaviour()
     {
         // Backward-compatibility guarantee: existing hosts that never pass an instanceStore
@@ -146,6 +219,22 @@ public class WorkflowRuntimeEngineInstanceStoreTests
             : base(logger, new SingleDefinitionStore(definition), sanitizer, instanceStore: instanceStore)
         {
         }
+    }
+
+    /// <summary>Proves a host can override ResolveIsAuthenticated to stamp new instances —
+    /// mirrors how CmsWorkflowEngine derives it from the live request's HttpContext.</summary>
+    private sealed class AlwaysAuthenticatedWorkflowRuntimeEngine : WorkflowRuntimeEngine
+    {
+        public AlwaysAuthenticatedWorkflowRuntimeEngine(
+            ILogger<AlwaysAuthenticatedWorkflowRuntimeEngine> logger,
+            IWorkflowDefinitionStore definitionStore,
+            IWorkflowContentSanitizer sanitizer,
+            IWorkflowInstanceStore instanceStore)
+            : base(logger, definitionStore, sanitizer, instanceStore: instanceStore)
+        {
+        }
+
+        protected override bool ResolveIsAuthenticated(string tenantId, string userId) => true;
     }
 
     private sealed class SingleDefinitionStore(WorkflowDefinitionFile definition) : IWorkflowDefinitionStore

--- a/src/UmbracoPrism.Core/Controllers/CmsWorkflowFileDownloadController.cs
+++ b/src/UmbracoPrism.Core/Controllers/CmsWorkflowFileDownloadController.cs
@@ -25,7 +25,7 @@ public class CmsWorkflowFileDownloadController(
     [HttpGet("{instanceId}/{fieldKey}")]
     public async Task<IActionResult> Download(string instanceId, string fieldKey, CancellationToken cancellationToken)
     {
-        var (tenantId, userId) = identityResolver.Resolve();
+        var (tenantId, userId, _) = identityResolver.Resolve();
         var reference = engine.TryGetOwnedFileReference(
             instanceId, tenantId, userId, CmsWorkflowQueue.AccessProfile, fieldKey);
 

--- a/src/UmbracoPrism.Core/Controllers/CmsWorkflowFileUploadController.cs
+++ b/src/UmbracoPrism.Core/Controllers/CmsWorkflowFileUploadController.cs
@@ -64,7 +64,7 @@ public class CmsWorkflowFileUploadController(
             return BadRequest("This field is no longer part of the current step.");
         }
 
-        var (tenantId, userId) = identityResolver.Resolve();
+        var (tenantId, userId, _) = identityResolver.Resolve();
         if (!engine.IsOwnedInstance(instanceId, tenantId, userId, CmsWorkflowQueue.AccessProfile))
         {
             return NotFound();

--- a/src/UmbracoPrism.Core/Controllers/WorkflowHubController.cs
+++ b/src/UmbracoPrism.Core/Controllers/WorkflowHubController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Extensions;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core;
@@ -12,12 +13,18 @@ using UmbracoPrism.Shared.Models.Workflow;
 namespace UmbracoPrism.Core.Controllers;
 
 /// <summary>
-/// Umbraco route-hijacking controller for the <c>workflowHub</c> document type.
-/// Displays all workflow instances for the authenticated member.
+/// Umbraco route-hijacking controller for the <c>workflowHub</c> document type — a single "My
+/// Workflows" surface across both workflow implementations a host may have running: the
+/// business-app one (<see cref="IBusinessAppWorkflowClient"/>'s default, unkeyed registration,
+/// talking to a remote business app) and Prism CMS Workflow (the keyed <c>"cms"</c>
+/// registration, in-process). Displays all workflow instances for the authenticated member from
+/// both, merged into one list — a member shouldn't need to know or care which implementation
+/// authored a given journey.
 /// </summary>
 public class WorkflowHubController : RenderController
 {
     private readonly IBusinessAppWorkflowClient _workflowClient;
+    private readonly IBusinessAppWorkflowClient _cmsWorkflowClient;
     private readonly IPublishedValueFallback _publishedValueFallback;
     private readonly IPublishedContentQuery _publishedContentQuery;
     private readonly ILogger<WorkflowHubController> _logger;
@@ -27,12 +34,14 @@ public class WorkflowHubController : RenderController
         ICompositeViewEngine compositeViewEngine,
         IUmbracoContextAccessor umbracoContextAccessor,
         IBusinessAppWorkflowClient workflowClient,
+        [FromKeyedServices("cms")] IBusinessAppWorkflowClient cmsWorkflowClient,
         IPublishedValueFallback publishedValueFallback,
         IPublishedContentQuery publishedContentQuery)
         : base(logger, compositeViewEngine, umbracoContextAccessor)
     {
         _logger = logger;
         _workflowClient = workflowClient;
+        _cmsWorkflowClient = cmsWorkflowClient;
         _publishedValueFallback = publishedValueFallback;
         _publishedContentQuery = publishedContentQuery;
     }
@@ -49,9 +58,14 @@ public class WorkflowHubController : RenderController
 
     private async Task<IActionResult> IndexAsync()
     {
-        var envelope = await _workflowClient.GetInstancesAsync();
+        var businessAppEnvelope = await _workflowClient.GetInstancesAsync();
+        var cmsEnvelope = await _cmsWorkflowClient.GetInstancesAsync();
+        var allInstances = businessAppEnvelope.Instances
+            .Concat(cmsEnvelope.Instances)
+            .OrderByDescending(i => i.LastUpdatedAt)
+            .ToList();
 
-        var activeInstances = envelope.Instances
+        var activeInstances = allInstances
             .Where(i => !i.IsCompleted)
             .Select(i => new WorkflowInstanceViewModel
             {
@@ -60,7 +74,7 @@ public class WorkflowHubController : RenderController
             })
             .ToList();
 
-        var completedInstances = envelope.Instances
+        var completedInstances = allInstances
             .Where(i => i.IsCompleted)
             .Select(i => new WorkflowInstanceViewModel
             {
@@ -98,7 +112,7 @@ public class WorkflowHubController : RenderController
             .ContentAtRoot()
             .SelectMany(root => root.DescendantsOrSelf())
             .FirstOrDefault(content =>
-                content.ContentType.Alias == "workflowPage"
+                (content.ContentType.Alias == "workflowPage" || content.ContentType.Alias == "cmsWorkflowPage")
                 && string.Equals(content.Value<string>("workflowKey"), summary.WorkflowKey, StringComparison.OrdinalIgnoreCase));
 
         if (workflowPage != null)

--- a/src/UmbracoPrism.Core/Models/PrismOidcConfiguration.cs
+++ b/src/UmbracoPrism.Core/Models/PrismOidcConfiguration.cs
@@ -6,6 +6,7 @@ using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Tokens;
 using UmbracoPrism.Core.Models;
 using UmbracoPrism.Core.Services;
+using UmbracoPrism.Core.Services.Workflow;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Client;
 using System.Security.Authentication;
@@ -510,7 +511,9 @@ public class PrismOidcConfiguration(IHttpContextAccessor httpContextAccessor, IP
                 props.RedirectUri = null;
                 await context.HttpContext.SignInAsync("PrismMemberCookie", principal, props);
 
-                // Tell the OIDC middleware to STOP. 
+                ClaimAnonymousWorkflowInstances(context.HttpContext, identity);
+
+                // Tell the OIDC middleware to STOP.
                 // If we don't call HandleResponse, it will try to sign in again and overwrite our cookie.
                 context.HandleResponse();
 
@@ -577,5 +580,56 @@ public class PrismOidcConfiguration(IHttpContextAccessor httpContextAccessor, IP
             }
         };
 
+    }
+
+    /// <summary>
+    /// A visitor who was browsing a CMS Workflow anonymously and has just signed in gets their
+    /// in-progress instance(s) re-keyed onto their new authenticated identity, so what would
+    /// otherwise become an orphaned, soon-to-expire anonymous session survives as a resumable
+    /// one under "My Workflows" instead. Reads <paramref name="newIdentity"/> directly rather
+    /// than <c>httpContext.User</c> — the sign-in cookie written moments ago only takes effect
+    /// on the *next* request, so the incoming request's principal is still whatever it was
+    /// before this callback ran (anonymous, or a different signed-in user), not the one just
+    /// authenticated.
+    /// </summary>
+    private void ClaimAnonymousWorkflowInstances(HttpContext httpContext, ClaimsIdentity newIdentity)
+    {
+        var services = httpContext.RequestServices;
+        // Resolved by concrete type, not IWorkflowRuntimeEngine — that interface isn't
+        // registered as a keyed service (only IBusinessAppWorkflowClient is, under "cms"), and
+        // a host that also registers its own business-app engine via AddPrismWorkflowEngine()
+        // would make an unkeyed IWorkflowRuntimeEngine lookup ambiguous. CmsWorkflowEngine
+        // itself is always registered by concrete type, so this is unambiguous regardless.
+        var engine = services.GetService<CmsWorkflowEngine>();
+        if (engine is null)
+        {
+            // A host using Prism's auth without its CMS Workflow feature — nothing to claim.
+            return;
+        }
+
+        var identityResolver = services.GetRequiredService<CmsWorkflowVisitorIdentityResolver>();
+        var anonymousUserId = identityResolver.PeekAnonymousVisitorId();
+        if (anonymousUserId is null)
+        {
+            return;
+        }
+
+        var newUserId = newIdentity.FindFirst("preferred_username")?.Value
+            ?? newIdentity.FindFirst(ClaimTypes.Email)?.Value;
+        if (string.IsNullOrWhiteSpace(newUserId))
+        {
+            return;
+        }
+
+        var tenantId = services.GetRequiredService<IPrismUserContext>().CurrentTenant?.Hostname ?? "default";
+
+        var claimed = engine.ClaimInstances(tenantId, anonymousUserId, newUserId);
+        if (claimed.Count > 0)
+        {
+            identityResolver.ClearAnonymousVisitorCookie();
+            logger.LogInformation(
+                "Claimed {Count} anonymous CMS Workflow instance(s) for tenant {TenantId} onto the newly signed-in user.",
+                claimed.Count, tenantId);
+        }
     }
 }

--- a/src/UmbracoPrism.Core/Services/Workflow/CmsWorkflowEngine.cs
+++ b/src/UmbracoPrism.Core/Services/Workflow/CmsWorkflowEngine.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using UmbracoPrism.Shared.Models.Workflow;
 using UmbracoPrism.Shared.Services.Sanitization;
@@ -21,9 +22,20 @@ public sealed class CmsWorkflowEngine(
     IWorkflowDefinitionStore definitionStore,
     IWorkflowContentSanitizer sanitizer,
     IWorkflowInstanceStore instanceStore,
+    IHttpContextAccessor httpContextAccessor,
     Func<WorkflowInstanceState, WorkflowDefinitionFile, StepDefinition, IReadOnlyDictionary<string, object?>?>? serviceInputsResolver = null)
     : WorkflowRuntimeEngine(logger, definitionStore, sanitizer, serviceInputsResolver, instanceStore)
 {
+    /// <summary>
+    /// A new instance is authenticated when the request creating it belongs to a signed-in
+    /// user — mirrors the same <c>User.Identity.IsAuthenticated</c> check <c>PrismUserContext</c>
+    /// makes, but read directly via <see cref="IHttpContextAccessor"/> rather than injecting
+    /// the scoped <c>IPrismUserContext</c> into this singleton engine (which would capture a
+    /// stale request the first time it resolved).
+    /// </summary>
+    protected override bool ResolveIsAuthenticated(string tenantId, string userId) =>
+        httpContextAccessor.HttpContext?.User?.Identity?.IsAuthenticated ?? false;
+
     /// <summary>
     /// Resolves a <c>file-upload</c> field's stored reference for a download endpoint — reuses
     /// the exact same ownership check (<see cref="WorkflowRuntimeEngine.CanAccessInstance"/>)

--- a/src/UmbracoPrism.Core/Services/Workflow/CmsWorkflowVisitorIdentityResolver.cs
+++ b/src/UmbracoPrism.Core/Services/Workflow/CmsWorkflowVisitorIdentityResolver.cs
@@ -22,19 +22,53 @@ public sealed class CmsWorkflowVisitorIdentityResolver(
     IPrismUserContext userContext,
     IHttpContextAccessor httpContextAccessor)
 {
-    private const string AnonymousVisitorCookieName = "PrismCmsWorkflowVisitor";
+    /// <summary>
+    /// Exposed so a caller outside the normal request flow — the sign-in claim hook, which
+    /// needs to read the visitor's pre-login correlation cookie directly rather than through
+    /// <see cref="Resolve"/> — can name the same cookie without duplicating the literal.
+    /// </summary>
+    public const string AnonymousVisitorCookieName = "PrismCmsWorkflowVisitor";
+
     private static readonly TimeSpan AnonymousVisitorTtl = TimeSpan.FromMinutes(30);
 
-    public (string TenantId, string UserId) Resolve()
+    public (string TenantId, string UserId, bool IsAuthenticated) Resolve()
     {
         var tenantId = userContext.CurrentTenant?.Hostname ?? "default";
 
         if (userContext.IsAuthenticated && !string.IsNullOrWhiteSpace(userContext.Email))
         {
-            return (tenantId, userContext.Email);
+            return (tenantId, userContext.Email, true);
         }
 
-        return (tenantId, ResolveAnonymousVisitorId());
+        return (tenantId, ResolveAnonymousVisitorId(), false);
+    }
+
+    /// <summary>
+    /// The current anonymous visitor cookie's value, if present — without minting or
+    /// refreshing one. For the sign-in claim hook, which only wants to know "was there an
+    /// anonymous session before this request authenticated," not start a new session.
+    /// </summary>
+    public string? PeekAnonymousVisitorId()
+    {
+        var httpContext = httpContextAccessor.HttpContext;
+        if (httpContext is null)
+        {
+            return null;
+        }
+
+        return httpContext.Request.Cookies.TryGetValue(AnonymousVisitorCookieName, out var existing)
+            && !string.IsNullOrWhiteSpace(existing)
+            ? existing
+            : null;
+    }
+
+    /// <summary>
+    /// Clears the anonymous visitor cookie once its instances have been claimed onto an
+    /// authenticated identity — the correlation it names no longer means anything.
+    /// </summary>
+    public void ClearAnonymousVisitorCookie()
+    {
+        httpContextAccessor.HttpContext?.Response.Cookies.Delete(AnonymousVisitorCookieName);
     }
 
     private string ResolveAnonymousVisitorId()

--- a/src/UmbracoPrism.Core/Services/Workflow/InProcessCmsWorkflowClient.cs
+++ b/src/UmbracoPrism.Core/Services/Workflow/InProcessCmsWorkflowClient.cs
@@ -26,7 +26,7 @@ public sealed class InProcessCmsWorkflowClient(
         string? action = null,
         CancellationToken cancellationToken = default)
     {
-        var (tenantId, userId) = identityResolver.Resolve();
+        var (tenantId, userId, _) = identityResolver.Resolve();
         return Task.FromResult(
             engine.GetCurrent(workflowKey, tenantId, userId, CmsWorkflowQueue.AccessProfile, instanceId, action));
     }
@@ -39,7 +39,7 @@ public sealed class InProcessCmsWorkflowClient(
         Dictionary<string, object?>? fieldValues = null,
         CancellationToken cancellationToken = default)
     {
-        var (tenantId, userId) = identityResolver.Resolve();
+        var (tenantId, userId, _) = identityResolver.Resolve();
         return Task.FromResult(
             engine.Advance(instanceId, tenantId, userId, CmsWorkflowQueue.AccessProfile, action, stateVersion, fieldValues));
     }
@@ -48,7 +48,7 @@ public sealed class InProcessCmsWorkflowClient(
         bool allowRefreshRetry = true,
         CancellationToken cancellationToken = default)
     {
-        var (tenantId, userId) = identityResolver.Resolve();
+        var (tenantId, userId, _) = identityResolver.Resolve();
         return Task.FromResult(engine.GetInstances(tenantId, userId));
     }
 }

--- a/src/UmbracoPrism.Core/Services/Workflow/UmbracoCmsWorkflowInstanceStore.cs
+++ b/src/UmbracoPrism.Core/Services/Workflow/UmbracoCmsWorkflowInstanceStore.cs
@@ -8,15 +8,25 @@ namespace UmbracoPrism.Core.Services.Workflow;
 
 /// <summary>
 /// <see cref="IWorkflowInstanceStore"/> backed by the prismCmsWorkflowInstance table — durable
-/// across an app-pool recycle, but each row carries a sliding <c>ExpiresUtc</c> so an instance
-/// still dies with the visitor's session rather than persisting indefinitely like a business
-/// workflow's instance history would.
+/// across an app-pool recycle. An anonymous visitor's row carries a sliding <c>ExpiresUtc</c>
+/// so it still dies with their session; an authenticated member's row
+/// (<see cref="WorkflowInstanceState.IsAuthenticated"/>) is stamped with <see cref="NeverExpires"/>
+/// instead, so signing in and coming back next week finds it exactly where it was left — see
+/// "My Workflows" (<c>WorkflowHubController</c>).
 /// </summary>
 public sealed class UmbracoCmsWorkflowInstanceStore(
     IUmbracoDatabaseFactory databaseFactory,
     TimeSpan? slidingExpiration = null) : IWorkflowInstanceStore
 {
     private readonly TimeSpan _slidingExpiration = slidingExpiration ?? TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Sentinel <c>ExpiresUtc</c> for an authenticated instance — deliberately not nullable-column
+    /// "no expiry" to avoid a schema migration; every expiry comparison in this store
+    /// (<c>WHERE ExpiresUtc &lt; @now</c> / <c>&gt;= @now</c>) already treats a value this far in
+    /// the future as "never," with no special-casing needed anywhere else.
+    /// </summary>
+    private static readonly DateTime NeverExpires = DateTime.MaxValue;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -42,10 +52,15 @@ public sealed class UmbracoCmsWorkflowInstanceStore(
             return false;
         }
 
-        // Refresh the sliding window on read — an active visitor keeps their instance alive.
-        db.Execute(
-            "UPDATE prismCmsWorkflowInstance SET ExpiresUtc = @0 WHERE InstanceId = @1",
-            DateTime.UtcNow.Add(_slidingExpiration), instanceId);
+        // Refresh the sliding window on read — an active anonymous visitor keeps their instance
+        // alive. Skipped for an authenticated instance: it's already at NeverExpires, and
+        // re-issuing the same value on every read would just be a wasted write.
+        if (!state.IsAuthenticated)
+        {
+            db.Execute(
+                "UPDATE prismCmsWorkflowInstance SET ExpiresUtc = @0 WHERE InstanceId = @1",
+                DateTime.UtcNow.Add(_slidingExpiration), instanceId);
+        }
 
         instance = state;
         return true;
@@ -54,7 +69,7 @@ public sealed class UmbracoCmsWorkflowInstanceStore(
     public void Save(WorkflowInstanceState instance)
     {
         using var db = databaseFactory.CreateDatabase();
-        var expiresUtc = DateTime.UtcNow.Add(_slidingExpiration);
+        var expiresUtc = instance.IsAuthenticated ? NeverExpires : DateTime.UtcNow.Add(_slidingExpiration);
         var json = JsonSerializer.Serialize(instance, JsonOptions);
 
         var rowsAffected = db.Execute(

--- a/src/UmbracoPrism.TestSite/TestSiteComposer.cs
+++ b/src/UmbracoPrism.TestSite/TestSiteComposer.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using UmbracoPrism.Core;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -64,6 +65,7 @@ public class TestSiteComposer : IComposer
                 sp.GetRequiredService<IWorkflowDefinitionStore>(),
                 sp.GetRequiredService<IWorkflowContentSanitizer>(),
                 sp.GetRequiredService<IWorkflowInstanceStore>(),
+                sp.GetRequiredService<IHttpContextAccessor>(),
                 (instance, definition, _) =>
                 {
                     var isJugglingLicenceWorkflow =

--- a/src/UmbracoPrism.WorkflowRuntime/Abstractions/IWorkflowRuntimeEngine.cs
+++ b/src/UmbracoPrism.WorkflowRuntime/Abstractions/IWorkflowRuntimeEngine.cs
@@ -40,6 +40,17 @@ public interface IWorkflowRuntimeEngine
 
     WorkflowInstanceListEnvelope GetInstances(string tenantId, string userId);
 
+    /// <summary>
+    /// Re-keys every instance owned by <paramref name="fromUserId"/> onto
+    /// <paramref name="toUserId"/> and marks each as authenticated — for a visitor who was
+    /// browsing anonymously and has just signed in, so their in-progress instance survives
+    /// as a resumable one instead of being orphaned under an identity nothing will ever
+    /// resolve to again. An instance is left alone (not claimed) if <paramref name="toUserId"/>
+    /// already owns an instance of that same workflow — claiming would silently discard
+    /// whichever the caller didn't return here. Returns the claimed instance ids.
+    /// </summary>
+    IReadOnlyList<string> ClaimInstances(string tenantId, string fromUserId, string toUserId);
+
     WorkflowQueueWorkListEnvelope GetQueueWorkItems(WorkflowAccessProfile accessProfile);
 
     IEnumerable<WorkflowInstanceState> GetAllInstances();

--- a/src/UmbracoPrism.WorkflowRuntime/Models/WorkflowInstanceState.cs
+++ b/src/UmbracoPrism.WorkflowRuntime/Models/WorkflowInstanceState.cs
@@ -16,6 +16,15 @@ public record WorkflowInstanceState
     public string UserId { get; init; } = "";
 
     /// <summary>
+    /// True when <see cref="UserId"/> identifies a signed-in user rather than an anonymous
+    /// visitor's correlation cookie. A store may use this to apply a longer-lived (or
+    /// unbounded) retention policy than it would for an anonymous session — see
+    /// <c>UmbracoCmsWorkflowInstanceStore</c>, whose 30-minute sliding expiry is skipped
+    /// entirely for authenticated instances.
+    /// </summary>
+    public bool IsAuthenticated { get; init; }
+
+    /// <summary>
     /// Primary cursor position. In single-queue workflows this is the only position.
     /// In multi-cursor mode this reflects the first active stage cursor for backward-compatibility
     /// with API consumers that read only this field.

--- a/src/UmbracoPrism.WorkflowRuntime/Services/WorkflowRuntimeEngine.cs
+++ b/src/UmbracoPrism.WorkflowRuntime/Services/WorkflowRuntimeEngine.cs
@@ -421,6 +421,50 @@ public class WorkflowRuntimeEngine : IWorkflowRuntimeEngine
         };
     }
 
+    public IReadOnlyList<string> ClaimInstances(string tenantId, string fromUserId, string toUserId)
+    {
+        if (string.IsNullOrWhiteSpace(fromUserId)
+            || string.IsNullOrWhiteSpace(toUserId)
+            || string.Equals(fromUserId, toUserId, StringComparison.Ordinal))
+        {
+            return [];
+        }
+
+        var allInstances = _instanceStore.GetAll().ToList();
+        var workflowsAlreadyOwned = allInstances
+            .Where(i => string.Equals(i.TenantId, tenantId, StringComparison.Ordinal)
+                     && string.Equals(i.UserId, toUserId, StringComparison.Ordinal))
+            .Select(i => i.WorkflowKey)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var claimed = new List<string>();
+        foreach (var instance in allInstances)
+        {
+            if (!string.Equals(instance.TenantId, tenantId, StringComparison.Ordinal)
+                || !string.Equals(instance.UserId, fromUserId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (workflowsAlreadyOwned.Contains(instance.WorkflowKey))
+            {
+                // The signed-in user already has their own instance of this workflow — leave
+                // the anonymous one behind rather than silently discarding whichever loses.
+                continue;
+            }
+
+            _instanceStore.Save(instance with
+            {
+                UserId = toUserId,
+                IsAuthenticated = true,
+                UpdatedAt = DateTimeOffset.UtcNow
+            });
+            claimed.Add(instance.InstanceId);
+        }
+
+        return claimed;
+    }
+
     public WorkflowQueueWorkListEnvelope GetQueueWorkItems(WorkflowAccessProfile accessProfile)
     {
         var items = _instanceStore.GetAll()
@@ -1028,7 +1072,8 @@ public class WorkflowRuntimeEngine : IWorkflowRuntimeEngine
         string logMessage,
         params object?[] additionalLogArgs)
     {
-        var instance = CreateNewInstance(workflowKey, tenantId, userId, definition.InitialState);
+        var instance = CreateNewInstance(
+            workflowKey, tenantId, userId, definition.InitialState, ResolveIsAuthenticated(tenantId, userId));
         if (InitializeNewInstance(instance, definition, action) is { } error)
         {
             return error;
@@ -1044,7 +1089,8 @@ public class WorkflowRuntimeEngine : IWorkflowRuntimeEngine
         string workflowKey,
         string tenantId,
         string userId,
-        string initialState)
+        string initialState,
+        bool isAuthenticated)
     {
         var now = DateTimeOffset.UtcNow;
         return new WorkflowInstanceState
@@ -1053,12 +1099,22 @@ public class WorkflowRuntimeEngine : IWorkflowRuntimeEngine
             WorkflowKey = workflowKey,
             TenantId = tenantId,
             UserId = userId,
+            IsAuthenticated = isAuthenticated,
             CurrentState = initialState,
             StateVersion = 0,
             CreatedAt = now,
             UpdatedAt = now
         };
     }
+
+    /// <summary>
+    /// Whether <paramref name="userId"/> identifies a signed-in user, for a store that wants
+    /// to apply a different retention policy for authenticated vs anonymous instances (see
+    /// <see cref="WorkflowInstanceState.IsAuthenticated"/>). The base engine has no identity
+    /// model of its own — always false — a host overrides this using whatever identity
+    /// resolution its own request pipeline already performs.
+    /// </summary>
+    protected virtual bool ResolveIsAuthenticated(string tenantId, string userId) => false;
 
     /// <summary>Evaluated calculation state for one render pass.</summary>
     protected sealed record CalculationRenderContext(


### PR DESCRIPTION
## Summary
- Anonymous CMS Workflow instances are now re-keyed onto a member's identity when they sign in mid-journey, instead of being orphaned and left to expire.
- Authenticated CMS Workflow instances persist indefinitely (`NeverExpires`) rather than sliding-window expiring like anonymous ones.
- `WorkflowHubController` ("My Workflows") now merges instances from both the business-app workflow client and the keyed CMS workflow client into one list.

## Test plan
- [x] `dotnet build UmbracoPrism.sln` — succeeds
- [x] `dotnet test src/UmbracoPrism.Core.Tests/` — 1007 passed, 0 failed
- [ ] Playwright `localhost-auth-session.spec.ts` new test (`anonymous CMS Workflow instance is claimed and resumable after signing in`) — needs the live Aspire stack to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)