### PR TITLE
Release: v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Umbraco Prism are documented here. This project follows [semantic versioning](https://semver.org/).
 
+## [v1.15.0] — 2026-07-25
+
+### New Features
+
+- **Anonymous CMS Workflow journeys survive signing in:** Start a CMS Workflow without signing in, then sign in partway through, and your in-progress journey now carries over automatically — it shows up as resumable under "My Workflows" instead of being silently lost when the anonymous session expires.
+
+### Bug Fixes & Improvements
+
+- "My Workflows" now shows in-progress and completed journeys from both workflow implementations (the business-app workflow client and Prism's own CMS Workflow) merged into a single list, instead of only the business-app ones.
+- An authenticated member's CMS Workflow instance no longer expires on a sliding 30-minute window — it persists until the journey is completed, so coming back days later resumes exactly where you left off.
+
+---
+
 ## [v1.14.0] — 2026-07-25
 
 ### New Features

--- a/src/UmbracoPrism.Client/package.json
+++ b/src/UmbracoPrism.Client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "umbracoprism-client",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
+++ b/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>UmbracoPrism</PackageId>
     <Title>Umbraco Prism</Title>
-    <Version>1.14.0</Version>
+    <Version>1.15.0</Version>
     <Authors>Jonny Muir</Authors>
     <Company>Umbraco Prism</Company>
     <Description>Multi-tenancy for Umbraco (v17+) with dynamic branding and stateless identity.</Description>


### PR DESCRIPTION
## Summary

**Minor** version bump, driven by `feat: claim anonymous CMS Workflow instances on sign-in` (merged in #115).

## Release notes

## [v1.15.0] — 2026-07-25

### New Features

- **Anonymous CMS Workflow journeys survive signing in:** Start a CMS Workflow without signing in, then sign in partway through, and your in-progress journey now carries over automatically — it shows up as resumable under "My Workflows" instead of being silently lost when the anonymous session expires.

### Bug Fixes & Improvements

- "My Workflows" now shows in-progress and completed journeys from both workflow implementations (the business-app workflow client and Prism's own CMS Workflow) merged into a single list, instead of only the business-app ones.
- An authenticated member's CMS Workflow instance no longer expires on a sliding 30-minute window — it persists until the journey is completed, so coming back days later resumes exactly where you left off.

## Post-merge

After this PR is merged to main, tag the merge commit to trigger the NuGet publish:

```bash
git checkout main && git pull
git tag v1.15.0
git push origin v1.15.0
```

This triggers `package-release.yml` which builds, packs, and publishes the NuGet package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)