### PR TITLE
fix: point the service-blueprint-editor vite build at Wayfinder.Editor

### DIFF
--- a/src/UmbracoPrism.Client/vite.service-blueprint-editor.config.ts
+++ b/src/UmbracoPrism.Client/vite.service-blueprint-editor.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     dedupe: ['react', 'react-dom'],
   },
   build: {
-    // This sends service-blueprint-editor assets to the ServiceBlueprintEditor package static web assets
-    outDir: '../UmbracoPrism.ServiceBlueprintEditor/wwwroot/dist',
+    // This sends service-blueprint-editor assets to the Wayfinder.Editor package static web assets
+    outDir: '../Wayfinder.Editor/wwwroot/dist',
     emptyOutDir: true,
     sourcemap: true,
     rollupOptions: {


### PR DESCRIPTION
## Summary

- Found while planning the Wayfinder repo split: the service-blueprint-editor vite config's `outDir` still pointed at the pre-rename `UmbracoPrism.ServiceBlueprintEditor` path, which no longer exists as a project. `npm run build` succeeded silently while writing to an orphaned directory nothing served — `MockBusinessApp` (which correctly serves from `../Wayfinder.Editor/wwwroot/dist`) was showing whatever stale content happened to be carried along by the directory rename, not a fresh build.

## Test plan

- [x] `npm run build` in `src/UmbracoPrism.Client` now writes to `../Wayfinder.Editor/wwwroot/dist` with fresh output; no orphaned `UmbracoPrism.ServiceBlueprintEditor` directory is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1fHzpoLYbjkkjrBPyHPNE