### PR TITLE
chore: bump to Wayfinder 0.4.3 / Wayfinder.Umbraco 0.5.1

### DIFF
--- a/src/UmbracoPrism.Core.Tests/ServiceDesign/Authoring/PaymentDemoReferenceServiceBlueprintTests.cs
+++ b/src/UmbracoPrism.Core.Tests/ServiceDesign/Authoring/PaymentDemoReferenceServiceBlueprintTests.cs
@@ -121,11 +121,26 @@ public class PaymentDemoReferenceWorkflowTests
             MockReferenceWorkflowQueues.BusinessUserProfile(),
             "confirm",
             workItem.StateVersion,
-            fieldValues: null);
+            new Dictionary<string, object?>
+            {
+                ["confirmationReference"] = "REF-100",
+                ["amountReceived"] = 42.50m
+            });
 
-        afterConfirmation.ResponseState.Should().Be("complete");
-        afterConfirmation.Render!.StateDisplayName.Should().Be("Payment complete");
-        afterConfirmation.Render.Components.Should().Contain(component =>
+        // "payment-complete" belongs to the web-user queue — the confirming business user has
+        // no visibility into it (Wayfinder dropped its implicit cross-queue fallback rendering:
+        // a queue with no visible work item now always gets ACCESS_DENIED), so the confirming
+        // actor's own envelope is correctly ACCESS_DENIED. Confirm completion from the applicant
+        // who actually owns that queue instead.
+        afterConfirmation.ResponseState.Should().Be("error");
+        var applicantView = engine.GetCurrent(
+            "payment-demo",
+            "tenant-1",
+            "applicant@example.com",
+            MockReferenceWorkflowQueues.WebUserProfile());
+        applicantView.ResponseState.Should().Be("complete");
+        applicantView.Render!.StateDisplayName.Should().Be("Payment complete");
+        applicantView.Render.Components.Should().Contain(component =>
             component.Type == "panel" && component.Heading == "Payment confirmed");
     }
 
@@ -264,7 +279,14 @@ public class PaymentDemoReferenceWorkflowTests
             financeWork.StateVersion,
             fieldValues: null);
 
-        complete.ResponseState.Should().Be("complete");
+        // financeProfile can only see "finance-queue" — "done" belongs to "citizen-queue", so
+        // the acting profile's own envelope from Advance is correctly ACCESS_DENIED (Wayfinder
+        // dropped its implicit cross-queue fallback rendering: a queue with no visible work item
+        // now always gets ACCESS_DENIED, never a peek at whatever stage the instance landed on).
+        // Confirm completion from the queue that actually owns "done" instead.
+        complete.ResponseState.Should().Be("error");
+        var citizenView = engine.GetCurrent("queue-test", "tenant-1", "user-1", citizenProfile);
+        citizenView.ResponseState.Should().Be("complete");
     }
 
     [Fact]

--- a/src/UmbracoPrism.Core.Tests/TagHelpers/FieldTagHelperContentTypesTests.cs
+++ b/src/UmbracoPrism.Core.Tests/TagHelpers/FieldTagHelperContentTypesTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Options;
 using Moq;
+using Wayfinder.Rendering.GovUk;
 using Wayfinder.Umbraco.Configuration;
 using Wayfinder.Umbraco.Models;
 using Wayfinder.Umbraco.Services;
@@ -49,6 +50,7 @@ public class FieldTagHelperContentTypesTests
         var helper = new ComponentTagHelper(
             htmlHelperMock.Object,
             new ComponentPartialResolver(viewEngineMock.Object),
+            new GovUkComponentRenderer(),
             Options.Create(new WayfinderServiceDesignOptions()))
         {
             Field       = field,
@@ -87,7 +89,11 @@ public class FieldTagHelperContentTypesTests
         var html = await ProcessAsync(field);
 
         html.Should().Contain(@"class=""govuk-inset-text""");
-        html.Should().Contain("We&#39;ll only use your contact details to respond to your enquiry.");
+        // Content-only field types pass the (already-sanitized) Content straight through — see
+        // Wayfinder.Rendering.GovUk's GovUkFields, which deliberately doesn't re-HTML-encode on
+        // top of IServiceContentSanitizer, since that would break any inline HTML a sanitized
+        // value is allowed to carry (e.g. a link). A bare apostrophe needs no escaping in HTML text.
+        html.Should().Contain("We'll only use your contact details to respond to your enquiry.");
         html.Should().NotContain("govuk-form-group");
     }
 
@@ -171,7 +177,7 @@ public class FieldTagHelperContentTypesTests
 
         html.Should().Contain(@"class=""govuk-notification-banner""");
         html.Should().Contain(@"role=""region""");
-        html.Should().Contain("We&#39;ll reply within 2 working days.");
+        html.Should().Contain("We'll reply within 2 working days.");
         html.Should().NotContain("govuk-input");
     }
 

--- a/src/UmbracoPrism.Core.Tests/UmbracoPrism.Core.Tests.csproj
+++ b/src/UmbracoPrism.Core.Tests/UmbracoPrism.Core.Tests.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder" Version="0.3.0" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.3.0" />
-    <PackageReference Include="Wayfinder.Umbraco" Version="0.4.1" />
+    <PackageReference Include="Wayfinder" Version="0.4.3" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.3" />
+    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
+++ b/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Umbraco.Cms.Core" Version="$(UmbracoVersion)" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="$(UmbracoVersion)" />
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="$(UmbracoVersion)" />
-    <PackageReference Include="Wayfinder" Version="0.3.0" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.3.0" />
-    <PackageReference Include="Wayfinder.Umbraco" Version="0.4.1" />
+    <PackageReference Include="Wayfinder" Version="0.4.3" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.3" />
+    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.MockBusinessApp/Services/BusinessAppProcessManager.cs
+++ b/src/UmbracoPrism.MockBusinessApp/Services/BusinessAppProcessManager.cs
@@ -192,7 +192,7 @@ public class BusinessAppProcessManager : ProcessManagerEngine
             visibleWorkItem.StageKey,
             resolvedTargetKey);
 
-        return BuildEnvelope(updated, definition, accessProfile, allowFallbackWhenHidden: true);
+        return BuildEnvelope(updated, definition, accessProfile);
     }
 
     public BusinessAppProcessManager(

--- a/src/UmbracoPrism.MockBusinessApp/UmbracoPrism.MockBusinessApp.csproj
+++ b/src/UmbracoPrism.MockBusinessApp/UmbracoPrism.MockBusinessApp.csproj
@@ -19,11 +19,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder" Version="0.3.0" />
-    <PackageReference Include="Wayfinder.Editor" Version="0.1.4" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.3.0" />
-    <PackageReference Include="Wayfinder.Engine.Api" Version="0.3.0" />
-    <PackageReference Include="Wayfinder.Engine.Mcp" Version="0.3.0" />
+    <PackageReference Include="Wayfinder" Version="0.4.3" />
+    <PackageReference Include="Wayfinder.Editor" Version="0.1.5" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.3" />
+    <PackageReference Include="Wayfinder.Engine.Api" Version="0.4.3" />
+    <PackageReference Include="Wayfinder.Engine.Mcp" Version="0.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.uSync/UmbracoPrism.uSync.csproj
+++ b/src/UmbracoPrism.uSync/UmbracoPrism.uSync.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="uSync.BackOffice" Version="17.3.5" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.3.0" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Bumps from Wayfinder 0.3.0 / Wayfinder.Umbraco 0.4.1 to Wayfinder 0.4.3 / Wayfinder.Umbraco 0.5.1 — crossing several upstream releases at once, so three compatibility fixes came with it:

- `BusinessAppProcessManager.Advance` called the base engine's `BuildEnvelope` with the now-removed `allowFallbackWhenHidden` parameter (Wayfinder dropped its implicit cross-queue fallback: a queue with no visible work item now always gets `ACCESS_DENIED`). Dropped the argument.
- `FieldTagHelperContentTypesTests` constructed `ComponentTagHelper` with its pre-`Wayfinder.Rendering.GovUk` 3-arg constructor; it now also takes a `GovUkComponentRenderer`.
- A few tests relied on either the removed queue-visibility fallback (now assert the acting profile's own envelope is `ACCESS_DENIED` and confirm completion from the profile that owns the resulting queue) or a null field submission through a stage with required fields (the engine's "never trust the client" validation now genuinely enforces those). Two HTML-encoding assertions were updated to match `Wayfinder.Rendering.GovUk`'s deliberate raw passthrough of already-sanitized content.

A genuine upstream bug surfaced while doing this and was fixed there first: a check-answers page's own summary-list echo of already-collected fields was wrongly re-demanded by the engine's field validation on that page's own submit (jonnymuir/Wayfinder#5, released as Wayfinder 0.4.3).

## Test plan
- [x] `dotnet build/test` — full `UmbracoPrism.Core.Tests` suite passes (847/847)
- [x] `npm run check:marketplace` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)