### PR TITLE
fix: bump to Wayfinder.Umbraco 0.5.2, require ci-tests.yml checks

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -3,48 +3,8 @@ name: CI Tests
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'README.md'
-      - 'MARKETPLACE.md'
-      - 'umbraco-marketplace.json'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'src/UmbracoPrism.Client/**'
-      - 'src/UmbracoPrism.AppHost/**'
-      - 'src/UmbracoPrism.Core/**'
-      - 'src/UmbracoPrism.Core.Tests/**'
-      - 'src/UmbracoPrism.KeycloakProxy/**'
-      - 'src/UmbracoPrism.MockBusinessApp/**'
-      - 'src/UmbracoPrism.ServiceDefaults/**'
-      - 'src/UmbracoPrism.Shared/**'
-      - 'src/UmbracoPrism.TestSite/**'
-      - 'keycloak/**'
-      - 'scripts/generate-marketplace-readme.mjs'
-      - 'scripts/validate-aspire-prereqs.mjs'
-      - 'ASPIRE_DEV.md'
-      - '.github/workflows/ci-tests.yml'
   push:
     branches: [ main ]
-    paths:
-      - 'README.md'
-      - 'MARKETPLACE.md'
-      - 'umbraco-marketplace.json'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'src/UmbracoPrism.Client/**'
-      - 'src/UmbracoPrism.AppHost/**'
-      - 'src/UmbracoPrism.Core/**'
-      - 'src/UmbracoPrism.Core.Tests/**'
-      - 'src/UmbracoPrism.KeycloakProxy/**'
-      - 'src/UmbracoPrism.MockBusinessApp/**'
-      - 'src/UmbracoPrism.ServiceDefaults/**'
-      - 'src/UmbracoPrism.Shared/**'
-      - 'src/UmbracoPrism.TestSite/**'
-      - 'keycloak/**'
-      - 'scripts/generate-marketplace-readme.mjs'
-      - 'scripts/validate-aspire-prereqs.mjs'
-      - 'ASPIRE_DEV.md'
-      - '.github/workflows/ci-tests.yml'
 
 jobs:
   marketplace-description:
@@ -220,3 +180,28 @@ jobs:
             src/UmbracoPrism.Client/test-results/
             src/UmbracoPrism.Client/playwright-report/
           retention-days: 7
+
+  # Single aggregate check so branch protection only needs to name one required status
+  # check per workflow — same pattern as squad-ci.yml's own "all" job. Named distinctly
+  # (not "all") since that name is already taken by squad-ci.yml's job in the same
+  # required-status-checks namespace; two jobs named "all" from different workflows would
+  # be indistinguishable to branch protection.
+  all:
+    name: ci-tests-all
+    runs-on: ubuntu-latest
+    needs: [marketplace-description, storybook-tests, core-tests, planning-workflow-editor-smoke, localhost-auth-playwright]
+    if: always()
+    steps:
+      - name: Decide whether checks have passed
+        run: |
+          if [[ "${{ needs.marketplace-description.result }}" == "success" \
+             && "${{ needs.storybook-tests.result }}" == "success" \
+             && "${{ needs.core-tests.result }}" == "success" \
+             && "${{ needs.planning-workflow-editor-smoke.result }}" == "success" \
+             && "${{ needs.localhost-auth-playwright.result }}" == "success" ]]; then
+            echo "All checks passed"
+            exit 0
+          else
+            echo "Some checks failed"
+            exit 1
+          fi

--- a/src/UmbracoPrism.Core.Tests/UmbracoPrism.Core.Tests.csproj
+++ b/src/UmbracoPrism.Core.Tests/UmbracoPrism.Core.Tests.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder" Version="0.4.3" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.3" />
-    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.2" />
+    <PackageReference Include="Wayfinder" Version="0.4.4" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.4" />
+    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.Core.Tests/UmbracoPrism.Core.Tests.csproj
+++ b/src/UmbracoPrism.Core.Tests/UmbracoPrism.Core.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
     <PackageReference Include="Wayfinder" Version="0.4.3" />
     <PackageReference Include="Wayfinder.Engine" Version="0.4.3" />
-    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.1" />
+    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
+++ b/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="$(UmbracoVersion)" />
     <PackageReference Include="Wayfinder" Version="0.4.3" />
     <PackageReference Include="Wayfinder.Engine" Version="0.4.3" />
-    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.1" />
+    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
+++ b/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Umbraco.Cms.Core" Version="$(UmbracoVersion)" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="$(UmbracoVersion)" />
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="$(UmbracoVersion)" />
-    <PackageReference Include="Wayfinder" Version="0.4.3" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.3" />
-    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.2" />
+    <PackageReference Include="Wayfinder" Version="0.4.4" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.4" />
+    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.MockBusinessApp/UmbracoPrism.MockBusinessApp.csproj
+++ b/src/UmbracoPrism.MockBusinessApp/UmbracoPrism.MockBusinessApp.csproj
@@ -19,11 +19,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder" Version="0.4.3" />
+    <PackageReference Include="Wayfinder" Version="0.4.4" />
     <PackageReference Include="Wayfinder.Editor" Version="0.1.5" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.3" />
-    <PackageReference Include="Wayfinder.Engine.Api" Version="0.4.3" />
-    <PackageReference Include="Wayfinder.Engine.Mcp" Version="0.4.3" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.4" />
+    <PackageReference Include="Wayfinder.Engine.Api" Version="0.4.4" />
+    <PackageReference Include="Wayfinder.Engine.Mcp" Version="0.4.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.uSync/UmbracoPrism.uSync.csproj
+++ b/src/UmbracoPrism.uSync/UmbracoPrism.uSync.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="uSync.BackOffice" Version="17.3.5" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.3" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

### Root cause of the localhost-auth-playwright failure
Bumping to Wayfinder.Umbraco 0.5.2 (jonnymuir/Wayfinder.Umbraco#3): a critical field-name mismatch broke every real HTML form submission through Wayfinder.Umbraco since v0.5.0. The rendering side switched to `Wayfinder.Rendering.GovUk`, whose fields post as `field:{fieldKey}`, but the controller's own submitted-field parsing was never updated off the old `fields[{fieldKey}]` bracket form. Every required field on every stage was rejected as missing, regardless of what the visitor typed or checked — the exact behavior `localhost-auth-session.spec.ts`'s "anonymous public service request instance is claimed and resumable after signing in" test caught (stuck on the same page with "is required" errors after checking both boxes and clicking Continue). Verified locally: reproduced the failure against a live Aspire+Keycloak stack, confirmed it disappears with the 0.5.2 fix in place.

### Why it didn't block the merge that introduced it
Branch protection only requires squad-ci.yml's `all` check (unrelated Squad framework tooling). `ci-tests.yml` — `core-tests`, `storybook-tests`, `marketplace-description`, and the two Playwright/Aspire lanes including `localhost-auth-playwright` — has never had its own aggregate job or been named in branch protection at all, unlike squad-ci.yml which got that fix deliberately. This PR adds a `ci-tests-all` aggregate job (distinctly named — `all` is already squad-ci.yml's job name in the same required-checks namespace) and drops `ci-tests.yml`'s path filters so it always runs (a required check gated by paths that don't match can block merges indefinitely).

**Follow-up needed after merge:** add `ci-tests-all` to the repo's branch protection ruleset's required status checks alongside squad-ci's `all` — I'll do that once this lands and reports a check under that name for the first time.

## Test plan
- [x] `dotnet build/test` — full `UmbracoPrism.Core.Tests` suite passes (847/847)
- [x] Verified the Wayfinder.Umbraco fix resolves the actual failing Playwright test locally (against a local NuGet feed carrying the fix, before it was published)
- [ ] CI green, including `localhost-auth-playwright`

🤖 Generated with [Claude Code](https://claude.com/claude-code)