### PR TITLE
refactor: bump to Wayfinder.Umbraco 0.6.0, drop dead IServiceRequestFieldValidator

### DIFF
--- a/src/UmbracoPrism.Core.Tests/Services/ServiceDesign/ServiceRequestFieldValidatorTests.cs
+++ b/src/UmbracoPrism.Core.Tests/Services/ServiceDesign/ServiceRequestFieldValidatorTests.cs
@@ -1,14 +1,11 @@
 using FluentAssertions;
-using Wayfinder.Umbraco.Models;
 using Wayfinder.Models.ServiceDesign;
-using Wayfinder.Umbraco.Services;
+using Wayfinder.Services.Validation;
 
 namespace UmbracoPrism.Core.Tests.Services.Workflow;
 
 public class ServiceRequestFieldValidatorTests
 {
-    private static readonly ServiceRequestFieldValidator Validator = new();
-
     // ------------------------------------------------------------------ Happy Path
 
     [Fact]
@@ -25,7 +22,7 @@ public class ServiceRequestFieldValidatorTests
             ["email"] = "jane@example.com"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
         result.Errors.Should().BeEmpty();
@@ -44,7 +41,7 @@ public class ServiceRequestFieldValidatorTests
             ["name"] = "Jane"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -81,7 +78,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["field"] = value };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -95,7 +92,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["password"] = "12345678" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -109,7 +106,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["code"] = "12345" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -125,7 +122,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["name"] = "" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("name");
@@ -141,7 +138,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["email"] = "" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("email");
@@ -164,7 +161,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["country"] = "" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("country");
@@ -187,7 +184,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["plan"] = "" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("plan");
@@ -208,7 +205,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["email"] = invalidEmail };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("email");
@@ -227,7 +224,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["age"] = invalidNumber };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("age");
@@ -246,7 +243,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["dob"] = invalidDate };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("dob");
@@ -271,7 +268,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["color"] = "yellow" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("color");
@@ -294,7 +291,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["membership"] = "hacked-admin" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("membership");
@@ -317,7 +314,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["features"] = "sso,injected-feature" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("features");
@@ -342,7 +339,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["username"] = "abc" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("username");
@@ -365,7 +362,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["code"] = "12345678901" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("code");
@@ -388,7 +385,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["postcode"] = "12AB" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("postcode");
@@ -411,7 +408,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["quantity"] = "5" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("quantity");
@@ -434,7 +431,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["rating"] = "10" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("rating");
@@ -456,7 +453,7 @@ public class ServiceRequestFieldValidatorTests
             ["injected_field"] = "malicious"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("injected_field");
@@ -472,7 +469,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string>();
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -489,7 +486,7 @@ public class ServiceRequestFieldValidatorTests
             ["comment"] = "<script>alert('xss')</script>"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -505,7 +502,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string>();
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -526,7 +523,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["interests"] = "sports,reading" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -547,7 +544,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["tags[]"] = "tech,design" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -568,7 +565,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["choice"] = "anything" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -589,7 +586,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["postcode"] = "AB12" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -611,7 +608,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["score"] = "75" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -632,7 +629,7 @@ public class ServiceRequestFieldValidatorTests
             ["age"] = "15"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(3);
@@ -653,7 +650,7 @@ public class ServiceRequestFieldValidatorTests
             ["amount"] = "0"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("amount");
@@ -676,7 +673,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["color"] = "red" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -700,7 +697,7 @@ public class ServiceRequestFieldValidatorTests
             // enquiry-type-other intentionally absent — trigger doesn't match
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue("the conditional field should be skipped when its trigger is not satisfied");
     }
@@ -721,7 +718,7 @@ public class ServiceRequestFieldValidatorTests
             // enquiry-type-other is absent but required when trigger matches
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("enquiry-type-other");
@@ -743,7 +740,7 @@ public class ServiceRequestFieldValidatorTests
             ["enquiry-type-other"] = "Something else entirely"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -761,7 +758,7 @@ public class ServiceRequestFieldValidatorTests
         var submitted = new Dictionary<string, string> { ["type"] = "other" }; // lowercase
 
         // The trigger value "other" matches VisibleWhen "Other" case-insensitively
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse("type-other is required when type=Other (case-insensitive)");
         result.Errors.Should().ContainKey("type-other");
@@ -784,7 +781,7 @@ public class ServiceRequestFieldValidatorTests
             ["message"] = "Hello from a test"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue("ReadOnly fields are skipped in server-side validation");
     }
@@ -803,7 +800,7 @@ public class ServiceRequestFieldValidatorTests
             ["email"] = "not-an-email"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue("ReadOnly field type/format validation is skipped server-side");
     }
@@ -835,7 +832,7 @@ public class ServiceRequestFieldValidatorTests
             ["message"] = "I have a question about the Prism package and how it integrates with Umbraco workflows."
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -859,7 +856,7 @@ public class ServiceRequestFieldValidatorTests
             ["message"] = "Some message that is long enough to pass min length validation easily"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue("optional conditional field absence should not fail validation");
     }
@@ -882,7 +879,7 @@ public class ServiceRequestFieldValidatorTests
             ["message"] = "Some message"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("enquiry-type-other");
@@ -905,7 +902,7 @@ public class ServiceRequestFieldValidatorTests
             ["dob-year"] = "1990"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -924,7 +921,7 @@ public class ServiceRequestFieldValidatorTests
             // day missing
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("dob");
@@ -944,7 +941,7 @@ public class ServiceRequestFieldValidatorTests
             ["dob-year"] = "99"  // 2-digit year
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
     }
@@ -958,7 +955,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string>(); // nothing submitted
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -978,7 +975,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["cost"] = value };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().Be(expectedValid);
     }
@@ -999,7 +996,7 @@ public class ServiceRequestFieldValidatorTests
             ["event-date-year"] = "1899"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("event-date");
@@ -1020,7 +1017,7 @@ public class ServiceRequestFieldValidatorTests
             ["event-date-year"] = "2101"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("event-date");
@@ -1041,7 +1038,7 @@ public class ServiceRequestFieldValidatorTests
             ["event-date-year"] = "1900"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -1060,7 +1057,7 @@ public class ServiceRequestFieldValidatorTests
             ["event-date-year"] = "2100"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -1086,7 +1083,7 @@ public class ServiceRequestFieldValidatorTests
             ["guidance"] = "transfer-rules,international-transfers,supporting-evidence"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -1110,7 +1107,7 @@ public class ServiceRequestFieldValidatorTests
             ["guidance"] = "transfer-rules"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse("a plain checkboxlist would accept a non-empty subset, but a required guidance-checklist must not");
         result.Errors.Should().ContainKey("guidance");
@@ -1132,7 +1129,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["guidance"] = "" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("guidance");
@@ -1154,7 +1151,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["guidance"] = "transfer-rules" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue("the require-all rule only applies when the field is required");
     }
@@ -1172,7 +1169,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string> { ["current-licence"] = "uploaded" };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }
@@ -1186,7 +1183,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string>();
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().ContainKey("current-licence");
@@ -1202,7 +1199,7 @@ public class ServiceRequestFieldValidatorTests
         };
         var submitted = new Dictionary<string, string>();
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
     }

--- a/src/UmbracoPrism.Core.Tests/TagHelpers/FieldTagHelperContentTypesTests.cs
+++ b/src/UmbracoPrism.Core.Tests/TagHelpers/FieldTagHelperContentTypesTests.cs
@@ -15,13 +15,12 @@ using Wayfinder.Umbraco.Models;
 using Wayfinder.Umbraco.Services;
 using Wayfinder.Umbraco.TagHelpers;
 using Wayfinder.Models.ServiceDesign;
+using Wayfinder.Services.Validation;
 
 namespace UmbracoPrism.Core.Tests.TagHelpers;
 
 public class FieldTagHelperContentTypesTests
 {
-    private static readonly ServiceRequestFieldValidator Validator = new();
-
     // ------------------------------------------------------------------ Helpers
 
     private static async Task<string> ProcessAsync(
@@ -200,7 +199,7 @@ public class FieldTagHelperContentTypesTests
             // Content fields deliberately absent — validator must not flag them
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeTrue();
         result.Errors.Should().BeEmpty();
@@ -219,7 +218,7 @@ public class FieldTagHelperContentTypesTests
         };
         var submitted = new Dictionary<string, string>();
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         result.IsValid.Should().BeFalse();
         result.Errors.Keys.Should().BeEquivalentTo(["your-role", "enquiry-type", "message"]);
@@ -278,7 +277,7 @@ public class FieldTagHelperContentTypesTests
             ["privacy-note"] = "injected value"
         };
 
-        var result = Validator.Validate(authoritative, submitted);
+        var result = FieldValueValidator.Validate(authoritative, submitted);
 
         // privacy-note is in authoritative so it's whitelisted — submitted value ignored harmlessly
         result.IsValid.Should().BeTrue();

--- a/src/UmbracoPrism.Core.Tests/UmbracoPrism.Core.Tests.csproj
+++ b/src/UmbracoPrism.Core.Tests/UmbracoPrism.Core.Tests.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder" Version="0.4.4" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.4" />
-    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.3" />
+    <PackageReference Include="Wayfinder" Version="0.4.5" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.5" />
+    <PackageReference Include="Wayfinder.Umbraco" Version="0.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
+++ b/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Umbraco.Cms.Core" Version="$(UmbracoVersion)" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="$(UmbracoVersion)" />
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="$(UmbracoVersion)" />
-    <PackageReference Include="Wayfinder" Version="0.4.4" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.4" />
-    <PackageReference Include="Wayfinder.Umbraco" Version="0.5.3" />
+    <PackageReference Include="Wayfinder" Version="0.4.5" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.5" />
+    <PackageReference Include="Wayfinder.Umbraco" Version="0.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.MockBusinessApp/UmbracoPrism.MockBusinessApp.csproj
+++ b/src/UmbracoPrism.MockBusinessApp/UmbracoPrism.MockBusinessApp.csproj
@@ -19,11 +19,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder" Version="0.4.4" />
+    <PackageReference Include="Wayfinder" Version="0.4.5" />
     <PackageReference Include="Wayfinder.Editor" Version="0.1.5" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.4" />
-    <PackageReference Include="Wayfinder.Engine.Api" Version="0.4.4" />
-    <PackageReference Include="Wayfinder.Engine.Mcp" Version="0.4.4" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.5" />
+    <PackageReference Include="Wayfinder.Engine.Api" Version="0.4.5" />
+    <PackageReference Include="Wayfinder.Engine.Mcp" Version="0.4.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.TestSite/Controllers/PublicServiceRequestPageController.cs
+++ b/src/UmbracoPrism.TestSite/Controllers/PublicServiceRequestPageController.cs
@@ -37,7 +37,6 @@ public class PublicServiceRequestPageController(
     IPublishedValueFallback publishedValueFallback,
     IAntiforgery antiforgery,
     IStageNonceService nonceService,
-    IServiceRequestFieldValidator fieldValidator,
     IServiceRequestFileStorage fileStorage,
     IUploadTokenService uploadTokenService)
     : ServiceRequestPageController<ServiceRequestPageViewModel>(
@@ -48,7 +47,6 @@ public class PublicServiceRequestPageController(
         publishedValueFallback,
         antiforgery,
         nonceService,
-        fieldValidator,
         fileStorage,
         uploadTokenService)
 {

--- a/src/UmbracoPrism.TestSite/Controllers/StagePageController.cs
+++ b/src/UmbracoPrism.TestSite/Controllers/StagePageController.cs
@@ -27,7 +27,6 @@ public class StagePageController(
     IPublishedValueFallback publishedValueFallback,
     IAntiforgery antiforgery,
     IStageNonceService nonceService,
-    IServiceRequestFieldValidator fieldValidator,
     IServiceRequestFileStorage fileStorage,
     IUploadTokenService uploadTokenService)
     : ServiceRequestPageController<StageViewModel>(
@@ -38,7 +37,6 @@ public class StagePageController(
         publishedValueFallback,
         antiforgery,
         nonceService,
-        fieldValidator,
         fileStorage,
         uploadTokenService)
 {

--- a/src/UmbracoPrism.uSync/UmbracoPrism.uSync.csproj
+++ b/src/UmbracoPrism.uSync/UmbracoPrism.uSync.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="uSync.BackOffice" Version="17.3.5" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.4" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Bumps to Wayfinder.Umbraco 0.6.0 (jonnymuir/Wayfinder.Umbraco#5), which deleted its own duplicate field validator (`IServiceRequestFieldValidator`/`ServiceRequestFieldValidator`/`ServiceRequestValidationResult`) and now calls `Wayfinder.Services.Validation.FieldValueValidator` directly — removing the constructor parameter entirely.
- Updates this repo's `PublicServiceRequestPageController`/`StagePageController` (TestSite), which explicitly forwarded `IServiceRequestFieldValidator` through their own constructors.
- Repoints two test files at the shared validator instead of deleting them — `ServiceRequestFieldValidatorTests` is a genuinely thorough 1200-line suite (far more so than existed anywhere else) covering the exact same behavior now living in `Wayfinder.Services.Validation.FieldValueValidator`, so it's kept, just retargeted.
- Bumps `Wayfinder`/`Wayfinder.Engine*` 0.4.4 -> 0.4.5 (jonnymuir/Wayfinder#8: guidance-checklist's required-completeness check never found its own submitted value — a live bug hit in this repo's own "Before you apply" guidance page).

## Test plan
- [x] `dotnet build/test` — full `UmbracoPrism.Core.Tests` suite passes (847/847)
- [x] `npm run check:marketplace` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)