### PR TITLE
chore: bump to Wayfinder 0.4.8, Wayfinder.Umbraco 0.6.5

### DIFF
--- a/docs/guides/reference-service-blueprint-contract.md
+++ b/docs/guides/reference-service-blueprint-contract.md
@@ -250,10 +250,10 @@ types for that queue today. Use `list_queue_capabilities` to discover a
 queue's supported types before drafting a stage for it.
 
 Capabilities are a contract each host declares about itself, never a runtime
-call to another host's process. `ComponentTypeCatalog`
+call to another host's process. `ComponentTypeRegistry`
 (`Wayfinder`) reflects `Component`'s closed, compile-time-fixed
 set of `[JsonDerivedType]` discriminators — since that assembly is shared by
-every host rendering the stock component catalog, `ComponentTypeCatalog.AllDiscriminators` is a
+every host rendering the stock component catalog, `ComponentTypeRegistry.AllDiscriminators` is a
 ready-made, honest declaration of "I render the stock Wayfinder component set", provable
 locally with no dependency on any other app actually running. A host with
 bespoke rendering (like `UmbracoPrism.MockBusinessApp`'s admin surface)

--- a/src/UmbracoPrism.Core.Tests/ServiceDesign/Authoring/PaymentDemoReferenceServiceBlueprintTests.cs
+++ b/src/UmbracoPrism.Core.Tests/ServiceDesign/Authoring/PaymentDemoReferenceServiceBlueprintTests.cs
@@ -295,7 +295,7 @@ public class PaymentDemoReferenceWorkflowTests
         var capabilities = MockReferenceWorkflowQueues.CapabilitiesProvider();
 
         capabilities.GetSupportedComponentTypes(MockReferenceWorkflowQueues.WebUser)
-            .Should().BeEquivalentTo(ComponentTypeCatalog.AllDiscriminators,
+            .Should().BeEquivalentTo(ComponentTypeRegistry.AllDiscriminators,
                 because: "web-user's declared capability must be Prism's own catalog contract, not a stale hand-copied list");
     }
 

--- a/src/UmbracoPrism.Core.Tests/ServiceDesign/Components/ComponentTypeRegistryTests.cs
+++ b/src/UmbracoPrism.Core.Tests/ServiceDesign/Components/ComponentTypeRegistryTests.cs
@@ -3,7 +3,7 @@ using Wayfinder.Models.ServiceDesign.Components;
 
 namespace UmbracoPrism.Core.Tests.ServiceDesign.Components;
 
-public class ComponentTypeCatalogTests
+public class ComponentTypeRegistryTests
 {
     // The full, exhaustive set of [JsonDerivedType] discriminators actually declared on
     // Component today. Cross-checked directly against Component.cs's attribute
@@ -20,7 +20,7 @@ public class ComponentTypeCatalogTests
     [Fact]
     public void AllDiscriminators_MatchesTheKnownGoodSet()
     {
-        ComponentTypeCatalog.AllDiscriminators.Should().BeEquivalentTo(ExpectedDiscriminators);
+        ComponentTypeRegistry.AllDiscriminators.Should().BeEquivalentTo(ExpectedDiscriminators);
     }
 
     [Fact]
@@ -29,17 +29,17 @@ public class ComponentTypeCatalogTests
         // TelComponent exists as a C# type but has no [JsonDerivedType] entry on Component
         // — it's already dead/unregistered, and stays that way; this test guards against it
         // being accidentally reintroduced without deliberately deciding to fix it.
-        ComponentTypeCatalog.AllDiscriminators.Should().NotContain("tel");
+        ComponentTypeRegistry.AllDiscriminators.Should().NotContain("tel");
     }
 
     [Fact]
     public void DiscriminatorFor_KnownComponent_ReturnsItsDiscriminator()
     {
-        ComponentTypeCatalog.DiscriminatorFor(new TextInputComponent { FieldKey = "x", Label = "X" })
+        ComponentTypeRegistry.DiscriminatorFor(new TextInputComponent { FieldKey = "x", Label = "X" })
             .Should().Be("text");
-        ComponentTypeCatalog.DiscriminatorFor(new FieldsetComponent())
+        ComponentTypeRegistry.DiscriminatorFor(new FieldsetComponent())
             .Should().Be("fieldset");
-        ComponentTypeCatalog.DiscriminatorFor(new SummaryListComponent())
+        ComponentTypeRegistry.DiscriminatorFor(new SummaryListComponent())
             .Should().Be("summary-list");
     }
 }

--- a/src/UmbracoPrism.Core.Tests/UmbracoPrism.Core.Tests.csproj
+++ b/src/UmbracoPrism.Core.Tests/UmbracoPrism.Core.Tests.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder" Version="0.4.6" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.6" />
-    <PackageReference Include="Wayfinder.Umbraco" Version="0.6.3" />
+    <PackageReference Include="Wayfinder" Version="0.4.8" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.8" />
+    <PackageReference Include="Wayfinder.Umbraco" Version="0.6.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
+++ b/src/UmbracoPrism.Core/UmbracoPrism.Core.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Umbraco.Cms.Core" Version="$(UmbracoVersion)" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="$(UmbracoVersion)" />
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="$(UmbracoVersion)" />
-    <PackageReference Include="Wayfinder" Version="0.4.6" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.6" />
-    <PackageReference Include="Wayfinder.Umbraco" Version="0.6.3" />
+    <PackageReference Include="Wayfinder" Version="0.4.8" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.8" />
+    <PackageReference Include="Wayfinder.Umbraco" Version="0.6.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.MockBusinessApp/Services/ReferenceQueues.cs
+++ b/src/UmbracoPrism.MockBusinessApp/Services/ReferenceQueues.cs
@@ -38,14 +38,14 @@ public static class ReferenceQueues
     /// component catalog is a closed, compile-time-fixed set declared on Component in
     /// Wayfinder — a package both TestSite and MockBusinessApp already reference —
     /// "what a stock Prism-Core web host renders" is provable locally via
-    /// ComponentTypeCatalog, not something that requires calling back into TestSite's
+    /// ComponentTypeRegistry, not something that requires calling back into TestSite's
     /// process. business-user is MockBusinessApp's own contract about itself, since it owns and
     /// writes that admin-rendering code directly.
     /// </summary>
     public static IQueueCapabilitiesProvider CapabilitiesProvider() => new StaticQueueCapabilitiesProvider(
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
         {
-            [WebUser] = ComponentTypeCatalog.AllDiscriminators,
+            [WebUser] = ComponentTypeRegistry.AllDiscriminators,
             [BusinessUser] = BusinessUserSupportedComponentTypes
         });
 }

--- a/src/UmbracoPrism.MockBusinessApp/UmbracoPrism.MockBusinessApp.csproj
+++ b/src/UmbracoPrism.MockBusinessApp/UmbracoPrism.MockBusinessApp.csproj
@@ -19,11 +19,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder" Version="0.4.6" />
-    <PackageReference Include="Wayfinder.Editor" Version="0.1.5" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.6" />
-    <PackageReference Include="Wayfinder.Engine.Api" Version="0.4.5" />
-    <PackageReference Include="Wayfinder.Engine.Mcp" Version="0.4.5" />
+    <PackageReference Include="Wayfinder" Version="0.4.8" />
+    <PackageReference Include="Wayfinder.Editor" Version="0.1.6" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.8" />
+    <PackageReference Include="Wayfinder.Engine.Api" Version="0.4.8" />
+    <PackageReference Include="Wayfinder.Engine.Mcp" Version="0.4.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UmbracoPrism.TestSite/TestSiteComposer.cs
+++ b/src/UmbracoPrism.TestSite/TestSiteComposer.cs
@@ -72,7 +72,7 @@ public class TestSiteComposer : IComposer
         builder.Services.AddSingleton<IQueueCapabilitiesProvider>(new StaticQueueCapabilitiesProvider(
             new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                [PublicVisitorQueue.Key] = ComponentTypeCatalog.AllDiscriminators
+                [PublicVisitorQueue.Key] = ComponentTypeRegistry.AllDiscriminators
             }));
 
         // Demonstrates the service-sourced field extension point for a logged-in member, shared

--- a/src/UmbracoPrism.uSync/UmbracoPrism.uSync.csproj
+++ b/src/UmbracoPrism.uSync/UmbracoPrism.uSync.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="uSync.BackOffice" Version="17.3.5" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" PrivateAssets="all" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" PrivateAssets="all" />
-    <PackageReference Include="Wayfinder.Engine" Version="0.4.6" />
+    <PackageReference Include="Wayfinder.Engine" Version="0.4.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
First bump of the Wayfinder chain to reach this repo since `v2.0.0` was tagged — brings in everything from the Calculations tab (fields/tables/series visual authoring) through the calc-validation-unification work and a real bug fix along the way (a summary-list child is never a genuine input, only a display echo).

Also fixes this repo's own build against an earlier upstream batch (component-catalog-extensibility): `ComponentTypeCatalog` was renamed to `ComponentTypeRegistry` — updated the two real call sites and the test file exercising it directly.

**Deliberately not tagging/releasing `UmbracoPrism.Core` in this PR** — `main` is 44 commits ahead of the last actual NuGet release (`v2.0.0`), including several breaking changes from the Wayfinder extraction. Bundling all of that into a release as a side effect of a routine dependency bump needs its own deliberate decision — this PR only gets the dependency current on `main`.

## Test plan
- [x] Verified against a local Wayfinder `-localtest` prerelease before the real Wayfinder fix was published, confirming the two failing tests were caused by the summary-list-child bug and nothing else
- [x] Re-verified against the real published `Wayfinder 0.4.8`/`Wayfinder.Umbraco 0.6.5`: `dotnet build`/`dotnet test` — 847/847 passed, including the two previously-failing tests
- [x] `dotnet nuget locals http-cache --clear` then restore — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLMQUUkavhfj2KcJJB1x8V